### PR TITLE
omega_tol: from fixed float to user defined float

### DIFF
--- a/pytagi/tagi_network.py
+++ b/pytagi/tagi_network.py
@@ -109,6 +109,7 @@ class NetProp(tagi.Network):
     init_method: str
     device: str
     ra_mt: float
+    omega_tol: float
 
     def __init__(self) -> None:
         super().__init__()

--- a/src/net_prop.cpp
+++ b/src/net_prop.cpp
@@ -1310,6 +1310,12 @@ void load_cfg(std::string net_file, Network &net)
                         ss >> f;
                         net.sigma_x = f;
                     }
+                } else if (key_words[k] == "omega_tol") {
+                    std::stringstream ss(line.substr(pos + key.size()));
+                    if (ss.good()) {
+                        ss >> f;
+                        net.omega_tol = f;
+                    }
                 } else if (key_words[k] == "init_method") {
                     std::stringstream ss(line.substr(pos + key.size()));
                     if (ss.good()) {

--- a/src/python_api.cu
+++ b/src/python_api.cu
@@ -332,7 +332,8 @@ PYBIND11_MODULE(cutagi, m) {
         .def_readwrite("init_method", &Network::init_method)
         .def_readwrite("noise_type", &Network::noise_type)
         .def_readwrite("device", &Network::device)
-        .def_readwrite("ra_mt", &Network::ra_mt);
+        .def_readwrite("ra_mt", &Network::ra_mt)
+        .def_readwrite("omega_tol", &Network::omega_tol);
 
     pybind11::class_<HrSoftmax>(m, "HrSoftmax")
         .def(pybind11::init<>())

--- a/src/python_api_cpu.cpp
+++ b/src/python_api_cpu.cpp
@@ -326,7 +326,8 @@ PYBIND11_MODULE(cutagi, m) {
         .def_readwrite("init_method", &Network::init_method)
         .def_readwrite("noise_type", &Network::noise_type)
         .def_readwrite("device", &Network::device)
-        .def_readwrite("ra_mt", &Network::ra_mt);
+        .def_readwrite("ra_mt", &Network::ra_mt)
+        .def_readwrite("omega_tol", &Network::omega_tol);
 
     pybind11::class_<HrSoftmax>(m, "HrSoftmax")
         .def(pybind11::init<>())


### PR DESCRIPTION
**Description**

The fixed omega_tol (1e-7) might cause numerical instability in some cases, e.g. when training model with diagonal covariance and testing it with full covariance, the model crushed with standard deviation = 0 in testing.

**Changes Made**

Allow user to define the omega_tol.

**Note for Reviewers**

n/a