### PR TITLE
Minor fixes to RegressionDataLoader and PredictionViz 

### DIFF
--- a/python_examples/data_loader.py
+++ b/python_examples/data_loader.py
@@ -119,10 +119,8 @@ class RegressionDataLoader(DataloaderBase):
         y_test = self.load_data_from_csv(y_test_file)
 
         # Normalizer
-        x_mean, x_std = self.normalizer.compute_mean_std(
-            np.concatenate((x_train, x_test)))
-        y_mean, y_std = self.normalizer.compute_mean_std(
-            np.concatenate((y_train, y_test)))
+        x_mean, x_std = self.normalizer.compute_mean_std(x_train)
+        y_mean, y_std = self.normalizer.compute_mean_std(y_train)
 
         x_train = self.normalizer.standardize(data=x_train,
                                               mu=x_mean,

--- a/visualizer.py
+++ b/visualizer.py
@@ -208,14 +208,14 @@ class PredictionViz:
                         y_pred + std_factor * sy_pred,
                         facecolor="red",
                         alpha=0.3,
-                        label=r"$\mathbb{E}[Y^{'}]\pm\sigma$")
+                        label=r"$\mathbb{{E}}[Y^{{'}}]\pm{}\sigma$".format(std_factor))
         if sy_test is not None:
             ax.fill_between(x_test,
                             y_test - std_factor * sy_test,
                             y_test + std_factor * sy_test,
                             facecolor="blue",
                             alpha=0.3,
-                            label=r"$y_{true}\pm\sigma$")
+                            label=r"$y_{{test}}\pm{}\sigma$".format(std_factor))
         if x_train is not None:
             if time_series:
                 marker = ""


### PR DESCRIPTION
### Description
1. Data scaling was done using information from the test set.
For more info about this issue: https://machinelearningmastery.com/data-preparation-without-data-leakage/
2. Plot was not showing the std_factor used for the uncertainty about the predictions.
### Changes Made
1. Fixed the RegressionDataLoader class to use only the training data for scaling.
2. Fixed the plot_predictions method of the PredictionViz class to show the std_factor used in the plot.
### Note for Reviewers
I tested the changes on Linux with the regression_runner.py file.
There were issues with the imports of the modules caused by the folder structure. I had to move around some files to overcome this, but you might not experience it testing on Mac.

