### PR TITLE
Exact covatiance formulation for mReLU

### DIFF
--- a/src/activation.cpp
+++ b/src/activation.cpp
@@ -410,7 +410,14 @@ void MixtureRelu::mixture_relu_mean_var(std::vector<float> &mu_z,
             mu_a[i] = omega * mu_z_til;
             var_a[i] =
                 omega * var_z_til + omega * (1 - omega) * powf(var_z_til, 2);
-            jcb[i] = powf(omega * kappa, 0.5);
+            // jcb[i] = powf(omega * kappa, 0.5); // Approximate formulation
+            jcb[i] =
+                (((pow(mu_z[i], 2) + var_z[i]) *  // Exact form. (Huber, 2020)
+                      normcdf_cpu(mu_z[i] / pow(var_z[i], 0.5)) +
+                  mu_z[i] * var_z[i] *
+                      normpdf_cpu(0.0f, mu_z[i], pow(var_z[i], 0.5))) -
+                 (mu_a[i] * mu_z[i])) /
+                var_z[i];
         } else {
             mu_a[i] = omega_tol;
             var_a[i] =
@@ -552,7 +559,7 @@ void MixtureSigmoid::mixture_sigmoid_mean_var(
                     cdf_lower * powf(1 + mu_a[i], 2) +
                     (1 - cdf_upper) * powf(1 - mu_a[i], 2)) /
                    4.0f;
-        jcb[i] = powf(omega * kappa, 0.5);
+        jcb[i] = powf(omega * kappa, 0.5);  // Approximate formulation
     }
 }
 void MixtureSigmoid::mixture_sigmoid_mean_var_mp(

--- a/src/activation_cuda.cu
+++ b/src/activation_cuda.cu
@@ -750,7 +750,14 @@ __global__ void mixture_relu(float const *mu_z, float const *var_z,
             mu_a[col] = omega * mu_z_til;
             var_a[col] =
                 omega * var_z_til + omega * (1.0f - omega) * powf(mu_z_til, 2);
-            jcb[col] = powf(omega * kappa, 0.5);
+            // jcb[col] = powf(omega * kappa, 0.5); //Approx. formulation
+            jcb[col] =  // Exact form. (Huber, 2020)
+                ((powf(mu_z[col], 2) + var_z[col]) * normcdff(-alpha) +
+                 mu_z[col] * powf(var_z[col], 0.5) *
+                     (1.0f / powf(2.0f * pi, 0.5)) *
+                     expf(-powf(-alpha, 2) / 2.0f) -
+                 (mu_a[col] * mu_z[col])) /
+                var_z[col];
         } else {
             mu_a[col] = omega_tol;
             var_a[col] =

--- a/src/activation_fun.cu
+++ b/src/activation_fun.cu
@@ -135,7 +135,14 @@ __global__ void mixture_relu(float const *mz, float const *Sz, float omega_tol,
             ma[apos + col] = omega * mz_til;
             Sa[apos + col] =
                 omega * Sz_til + omega * (1.0f - omega) * powf(mz_til, 2);
-            J[apos + col] = powf(omega * kappa, 0.5);
+            // J[apos + col] = powf(omega * kappa, 0.5); // Approx. formulation
+            J[apos + col] = (((powf(mz[zpos + col], 2) + Sz[zpos + col]) *
+                                  normcdff(-alpha) +
+                              mz[zpos + col] * powf(Sz[zpos + col], 0.5) *
+                                  (1.0f / powf(2.0f * pi, 0.5)) *
+                                  expf(-powf(-alpha, 2) / 2.0f)) -
+                             (ma[apos + col] * mz[zpos + col])) /
+                            Sz[zpos + col];
         } else {
             ma[apos + col] = omega_tol;
             Sa[apos + col] =

--- a/src/activation_fun_cpu.cpp
+++ b/src/activation_fun_cpu.cpp
@@ -240,7 +240,16 @@ void mixture_relu_cpu(std::vector<float> &mz, std::vector<float> &Sz,
             ma[i + a_pos] = omega * mz_til;
             Sa[i + a_pos] =
                 omega * Sz_til + omega * (1 - omega) * powf(mz_til, 2);
-            J[i + a_pos] = powf(omega * kappa, 0.5);
+            // J[i + a_pos] = powf(omega * kappa, 0.5); // Approximate
+            // formulation
+            J[i + a_pos] =  // Exact(Huber, 2020)
+                (((pow(mz[z_pos + i], 2) + Sz[z_pos + i]) *
+                      normcdf_cpu(mz[z_pos + i] / pow(Sz[z_pos + i], 0.5)) +
+                  mz[z_pos + i] * Sz[z_pos + i] *
+                      normpdf_cpu(0.0f, mz[z_pos + i],
+                                  pow(Sz[z_pos + i], 0.5))) -
+                 (ma[i + a_pos] * mz[z_pos + i])) /
+                Sz[z_pos + i];
         } else {
             ma[i + a_pos] = omega_tol;
             Sa[i + a_pos] =


### PR DESCRIPTION
Replaced the approximate formulation for the mReLU covariance by the exact formulation from Huber (2020, https://arxiv.org/abs/2009.01730).

I have tested the CPU and GPU versions for both the current as well and the new pyTAGI_v1  