### PR TITLE
Transitioning changes from V0 to V1 for heteroscedastic cases only

### DIFF
--- a/include/struct_var.h
+++ b/include/struct_var.h
@@ -127,7 +127,9 @@ struct Network {
         init_method: Initalization method e.g. He and Xavier
         gain_w: Gain for weight parameters when initializing
         gain_b: Gain for biases parameters when initializing
-        noise_gain : Gain fof biases parameters relating to noise's hidden
+        out_gain : Gain for weight parameters relating to output's hidden
+            states
+        noise_gain : Gain fof weight parameters relating to noise's hidden
             states
         w_pos: Weights weight position for each layer in the vector of weights
         b_pos: Biases position for each layer in the vector of biases
@@ -235,6 +237,7 @@ struct Network {
     float sigma_v = 0.0f;
     float sigma_x = 0.0f;
     std::string noise_type = "none";
+    float out_gain = 1.0f;
     float noise_gain = 0.5f;
     std::vector<float> mu_v2b;
     std::vector<float> sigma_v2b;
@@ -445,7 +448,7 @@ struct NetConfig {
     std::vector<int> layers, nodes, kernels, strides, widths, heights, filters,
         pads, pad_types, shortcuts, activations;
     std::vector<float> mu_v2b, sigma_v2b;
-    float sigma_v, sigma_v_min, sigma_x, decay_factor_sigma_v, noise_gain;
+    float sigma_v, sigma_v_min, sigma_x, decay_factor_sigma_v, out_gain, noise_gain;
     int batch_size, input_seq_len, output_seq_len, seq_stride;
     bool multithreading = true, collect_derivative = false, is_full_cov = false;
     std::string init_method = "Xavier", noise_type = "none", device = "cpu";

--- a/pytagi/tagi_network.py
+++ b/pytagi/tagi_network.py
@@ -61,7 +61,9 @@ class NetProp(tagi.Network):
                    layers
         last_backward_layer: Index of last layer whose hidden states are updated
         nye: Number of observation for hierarchical softmax
-        noise_gain : Gain fof biases parameters relating to noise's hidden
+        out_gain : Gain for weight parameters relating to output's hidden
+            states
+        noise_gain : Gain for weight parameters relating to noise's hidden
             states
         noise_type: homosce or heteros
         batch_size: Number of batches of data
@@ -98,6 +100,7 @@ class NetProp(tagi.Network):
     is_output_ud: bool
     last_backward_layer: int
     nye: int
+    out_gain: float
     noise_gain: float
     noise_type: str
     batch_size: int

--- a/src/net_init.cpp
+++ b/src/net_init.cpp
@@ -60,7 +60,7 @@ void map_config_to_prop(NetConfig &config, Network &net) {
     net.mu_v2b = config.mu_v2b;
     net.sigma_v2b = config.sigma_v2b;
     net.noise_gain = config.noise_gain;
-    net.noise_gain = config.out_gain;
+    net.out_gain = config.out_gain;
     net.batch_size = config.batch_size;
     net.input_seq_len = config.input_seq_len;
     net.output_seq_len = config.output_seq_len;

--- a/src/net_init.cpp
+++ b/src/net_init.cpp
@@ -60,6 +60,7 @@ void map_config_to_prop(NetConfig &config, Network &net) {
     net.mu_v2b = config.mu_v2b;
     net.sigma_v2b = config.sigma_v2b;
     net.noise_gain = config.noise_gain;
+    net.noise_gain = config.out_gain;
     net.batch_size = config.batch_size;
     net.input_seq_len = config.input_seq_len;
     net.output_seq_len = config.output_seq_len;

--- a/src/python_api.cu
+++ b/src/python_api.cu
@@ -321,6 +321,7 @@ PYBIND11_MODULE(cutagi, m) {
         .def_readwrite("last_backward_layer", &Network::last_backward_layer)
         .def_readwrite("nye", &Network::nye)
         .def_readwrite("decay_factor_sigma_v", &Network::decay_factor_sigma_v)
+        .def_readwrite("out_gain", &Network::out_gain)
         .def_readwrite("noise_gain", &Network::noise_gain)
         .def_readwrite("batch_size", &Network::batch_size)
         .def_readwrite("input_seq_len", &Network::input_seq_len)

--- a/src/python_api_cpu.cpp
+++ b/src/python_api_cpu.cpp
@@ -315,6 +315,7 @@ PYBIND11_MODULE(cutagi, m) {
         .def_readwrite("last_backward_layer", &Network::last_backward_layer)
         .def_readwrite("nye", &Network::nye)
         .def_readwrite("decay_factor_sigma_v", &Network::decay_factor_sigma_v)
+        .def_readwrite("out_gain", &Network::out_gain)
         .def_readwrite("noise_gain", &Network::noise_gain)
         .def_readwrite("batch_size", &Network::batch_size)
         .def_readwrite("input_seq_len", &Network::input_seq_len)


### PR DESCRIPTION
changes are made to add “out_gain” in the files below wherever noise_gain was also found. 
net_init.cpp
net_prop.cpp
struct_var.h
pytagi/tagi_network.py
python_api_cpu.cpp
python_api.cu

These changes should only affect heteroscedastic case study as the changes were made in the “gaussian_param_init_ni” function inside net_prop.cpp as shown in the below screenshot.

<img width="831" alt="Screen Shot 2024-04-08 at 6 04 52 PM" src="https://github.com/lhnguyen102/cuTAGI/assets/69599126/10d245a7-8f70-423a-8894-b97d8241ec38">

Please review these changes and we can proceed for merging into the main branch.