### PR TITLE
Fixing issues with Mixture-based act()

### DIFF
--- a/src/activation.cpp
+++ b/src/activation.cpp
@@ -3,7 +3,7 @@
 // Description:  ...
 // Authors:      Luong-Ha Nguyen & James-A. Goulet
 // Created:      October 09, 2023
-// Updated:      March 22, 2024
+// Updated:      April 14, 2024
 // Contact:      luongha.nguyen@gmail.com & james.goulet@polymtl.ca
 // License:      This code is released under the MIT License.
 ////////////////////////////////////////////////////////////////////////////////
@@ -234,12 +234,11 @@ void mixture_sigmoid_mean_var(std::vector<float> &mu_z,
         // Moments calculations (L. Alric, 2024)
         mu_a[i] = (mu_z[i] + 1) * cdf_l + (mu_z[i] - 1) * cdf_u +
                   std_z * (pdf_l - pdf_u) - mu_z[i];
-        var_a[i] = (cdf_l * (var_z[i] - powf(mu_z[i], 2) - 2 * mu_z[i] - 1) +
-                    cdf_u * (var_z[i] - powf(mu_z[i], 2) + 2 * mu_z[i] - 1) +
-                    std_z * (pdf_u * (mu_z[i] - 1) - pdf_l * (mu_z[i] + 1)) -
-                    powf(mu_a[i], 2) + 2 * mu_a[i] * mu_z[i] +
-                    powf(mu_z[i], 2) - var_z[i] + 2) /
-                   4.0f;
+        var_a[i] = std::max(0.000001f, (cdf_l * (var_z[i] - powf(mu_z[i], 2)
+                    - 2 * mu_z[i] - 1) + cdf_u * (var_z[i] - powf(mu_z[i], 2)
+                    + 2 * mu_z[i] - 1) + std_z * (pdf_u * (mu_z[i] - 1) - pdf_l
+                    * (mu_z[i] + 1)) - powf(mu_a[i], 2) + 2 * mu_a[i] * mu_z[i]
+                    + powf(mu_z[i], 2) - var_z[i] + 2) / 4.0f);
         mu_a[i] = mu_a[i] / 2.0f + 0.5f;
         jcb[i] = (cdf_u + cdf_l - 1) / 2.0f;
     }
@@ -298,11 +297,12 @@ void mixture_tanh_mean_var(std::vector<float> &mu_z, std::vector<float> &var_z,
         // Moments calculations (L. Alric, 2024)
         mu_a[i] = (mu_z[i] + 1) * cdf_l + (mu_z[i] - 1) * cdf_u +
                   std_z * (pdf_l - pdf_u) - mu_z[i];
-        var_a[i] = cdf_l * (var_z[i] - powf(mu_z[i], 2) - 2 * mu_z[i] - 1) +
+        var_a[i] = std::max(0.000001f, cdf_l *
+                   (var_z[i] - powf(mu_z[i], 2) - 2 * mu_z[i] - 1) +
                    cdf_u * (var_z[i] - powf(mu_z[i], 2) + 2 * mu_z[i] - 1) +
                    std_z * (pdf_u * (mu_z[i] - 1) - pdf_l * (mu_z[i] + 1)) -
                    powf(mu_a[i], 2) + 2 * mu_a[i] * mu_z[i] + powf(mu_z[i], 2) -
-                   var_z[i] + 2;
+                   var_z[i] + 2);
         jcb[i] = cdf_u + cdf_l - 1;
     }
 }

--- a/src/activation_cuda.cu
+++ b/src/activation_cuda.cu
@@ -764,13 +764,13 @@ __global__ void mixture_sigmoid_mean_var_cuda(float const *mu_z,
         // Moments calculations (L. Alric, 2024)
         mu_a[col] = (mu_z[col] + 1) * cdf_l + (mu_z[col] - 1) * cdf_u +
                     std_z * (pdf_l - pdf_u) - mu_z[col];
-        var_a[col] =
+        var_a[col] = max(0.000001f,
             (cdf_l * (var_z[col] - powf(mu_z[col], 2) - 2 * mu_z[col] - 1) +
              cdf_u * (var_z[col] - powf(mu_z[col], 2) + 2 * mu_z[col] - 1) +
              std_z * (pdf_u * (mu_z[col] - 1) - pdf_l * (mu_z[col] + 1)) -
              powf(mu_a[col], 2) + 2 * mu_a[col] * mu_z[col] +
              powf(mu_z[col], 2) - var_z[col] + 2) /
-            4.0f;
+            4.0f);
         mu_a[col] = mu_a[col] / 2.0f + 0.5f;
         jcb[col] = (cdf_u + cdf_l - 1) / 2.0f;
     }
@@ -800,12 +800,12 @@ __global__ void mixture_tanh_mean_var_cuda(float const *mu_z,
         // Moments calculations (L. Alric, 2024)
         mu_a[col] = (mu_z[col] + 1) * cdf_l + (mu_z[col] - 1) * cdf_u +
                     std_z * (pdf_l - pdf_u) - mu_z[col];
-        var_a[col] =
+        var_a[col] = max(0.000001f,
             cdf_l * (var_z[col] - powf(mu_z[col], 2) - 2 * mu_z[col] - 1) +
             cdf_u * (var_z[col] - powf(mu_z[col], 2) + 2 * mu_z[col] - 1) +
             std_z * (pdf_u * (mu_z[col] - 1) - pdf_l * (mu_z[col] + 1)) -
             powf(mu_a[col], 2) + 2 * mu_a[col] * mu_z[col] +
-            powf(mu_z[col], 2) - var_z[col] + 2;
+            powf(mu_z[col], 2) - var_z[col] + 2);
         jcb[col] = cdf_u + cdf_l - 1;
     }
 }


### PR DESCRIPTION
# Description

This PR fixes the issues we were having with the mixture-based activation functions for the LSTM layer. 

# Changes Made

The changes made are simple; take `max(1E-6, var_a)` for the `mixture_sigmoid` and `mixture_tanh` activation functions.  

# Note for Reviewers

I diagnosed the issue by first benchmarking the `ReLU` vs. `MixtureReLU`, `Sigmoid` vs. `MixtureSigmoid` &  `Tanh` vs. `MixtureTanh` on the MNIST dataset using `FNN` and `CNN` architectures. The bottomline is that `ReLU` outperforms `MixtureReLU` but `MixtureSigmoid` & `MixtureTanh` outperform their locally linearized counterpart. In no case there was any numerical errors while running the classification setup.

When running on time series with the LSTM architecture, I realized that the `nan` values occurred only when both the candidate and input gates were using mixture-based activation functions. By imposing a minimum value of 1E-6 for the variance of the mixture sigmoid and tanh gates, we fix the issue without affecting the performance on either the LSTM nor on the classification.

I did not change the activation function for the LSTM layer in this PR as we will first go through an extensive benchmark to decide which of the locally linearized or the mixture-based perform better. This fix should enable to go forward with the remax for the attention mechanism. 