### PR TITLE
Fix bugs estimating delta to update LSTM's hidden states

### DIFF
--- a/src/lstm_layer.cpp
+++ b/src/lstm_layer.cpp
@@ -660,17 +660,17 @@ void lstm_delta_mean_var_z_worker(
             // Forget gate
             Czz_f = Jca[k] * mo_ga[k] * Jf_ga[k] *
                     mw[(ni + no) * j + z + w_pos_f] * mc_prev[k];
-            sum_mf += Czz_f * delta_m[i];
+            sum_mf += Czz_f * delta_m_out[i];
 
             // Input gate
             Czz_i = Jca[k] * mo_ga[k] * Ji_ga[k] *
                     mw[(ni + no) * j + z + w_pos_i] * mc_ga[k];
-            sum_mi += Czz_i * delta_m[i];
+            sum_mi += Czz_i * delta_m_out[i];
 
             // Cell state gate
             Czz_c = Jca[k] * mo_ga[k] * Jc_ga[k] *
                     mw[(ni + no) * j + z + w_pos_c] * mi_ga[k];
-            sum_mc += Czz_c * delta_m[i];
+            sum_mc += Czz_c * delta_m_out[i];
 
             // Output gate
             Czz_o = Jo_ga[k] * mw[(ni + no) * j + z + w_pos_o] * mca[k];

--- a/src/lstm_layer_cuda.cu
+++ b/src/lstm_layer_cuda.cu
@@ -314,17 +314,17 @@ NOTE: All LSTM states excepted mc_prev are from the next layer e.g., mi_ga(l+1)
             // Forget gate
             Czz_f = Jca[k] * mo_ga[k] * Jf_ga[k] *
                     mw[(ni + no) * j + col + w_pos_f] * mc_prev[k];
-            sum_mf += Czz_f * delta_m[i];
+            sum_mf += Czz_f * delta_m_out[i];
 
             // Input gate
             Czz_i = Jca[k] * mo_ga[k] * Ji_ga[k] *
                     mw[(ni + no) * j + col + w_pos_i] * mc_ga[k];
-            sum_mi += Czz_i * delta_m[i];
+            sum_mi += Czz_i * delta_m_out[i];
 
             // Cell state gate
             Czz_c = Jca[k] * mo_ga[k] * Jc_ga[k] *
                     mw[(ni + no) * j + col + w_pos_c] * mi_ga[k];
-            sum_mc += Czz_c * delta_m[i];
+            sum_mc += Czz_c * delta_m_out[i];
 
             // Output gate
             Czz_o = Jo_ga[k] * mw[(ni + no) * j + col + w_pos_o] * mca[k];


### PR DESCRIPTION
In LSTM's backward pass, fix the bugs when estimating delta that needed to update the LSTM's hidden states and parameters.

