### PR TITLE
Fix Bugs in mRELU

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,7 @@ endif()
 list(APPEND CUDA_NVCC_FLAGS "--expt-extended-lambda")
 list(APPEND CUDA_NVCC_FLAGS "--expt-relaxed-constexpr")
 # list(APPEND CUDA_NVCC_FLAGS "--use_fast_math")
-list(APPEND CUDA_NVCC_FLAGS "-lineinfo")
+# list(APPEND CUDA_NVCC_FLAGS "-lineinfo")
 
 if(APPLE)
   set(CMAKE_CXX_FLAGS_DEBUG "-gdwarf-4")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,7 @@ endif()
 # NOTE: This might need to change for higher CUDA version
 list(APPEND CUDA_NVCC_FLAGS "--expt-extended-lambda")
 list(APPEND CUDA_NVCC_FLAGS "--expt-relaxed-constexpr")
-list(APPEND CUDA_NVCC_FLAGS "--use_fast_math")
+# list(APPEND CUDA_NVCC_FLAGS "--use_fast_math")
 list(APPEND CUDA_NVCC_FLAGS "-lineinfo")
 
 if(APPLE)

--- a/examples/cifar_resnet_bench.py
+++ b/examples/cifar_resnet_bench.py
@@ -1,23 +1,138 @@
+# Temporary import. It will be removed in the final vserion
+import os
+import sys
+
+# Add the 'build' directory to sys.path in one line
+sys.path.append(
+    os.path.normpath(os.path.join(os.path.dirname(__file__), "..", "build"))
+)
 import fire
 import numpy as np
 import torch
 import torchvision
-import torchvision.transforms as transforms
+import torchvision.transforms.v2 as transforms
 from torch.utils.data import DataLoader
 from tqdm import tqdm
 import torch.nn as nn
 import torch.optim as optim
 
 from pytagi import HRCSoftmaxMetric, Utils, exponential_scheduler
-from pytagi.nn import OutputUpdater
+from pytagi.nn import (
+    AvgPool2d,
+    BatchNorm2d,
+    Conv2d,
+    Linear,
+    OutputUpdater,
+    ReLU,
+    MixtureReLU,
+    Sequential,
+)
 from examples.tagi_resnet_model import resnet18_cifar10
 from examples.torch_resnet_model import ResNet18
 
-torch.manual_seed(42)
+torch.manual_seed(17)
 
 # Constants for dataset normalization
-NORMALIZATION_MEAN = (0.4914, 0.4822, 0.4465)
-NORMALIZATION_STD = (0.2023, 0.1994, 0.2010)
+NORMALIZATION_MEAN = [0.4914, 0.4822, 0.4465]
+NORMALIZATION_STD = [0.2470, 0.2435, 0.2616]
+
+TAGI_CNN_NET = Sequential(
+    # 32x32
+    Conv2d(3, 32, 5, bias=True, padding=2, in_width=32, in_height=32),
+    # BatchNorm2d(32),
+    MixtureReLU(),
+    AvgPool2d(2, 2),
+    # 16x16
+    Conv2d(32, 32, 5, bias=True, padding=2),
+    # BatchNorm2d(32),
+    MixtureReLU(),
+    AvgPool2d(2, 2),
+    # 8x8
+    Conv2d(32, 64, 5, bias=True, padding=2),
+    # BatchNorm2d(64),
+    MixtureReLU(),
+    AvgPool2d(2, 2),
+    # 4x4
+    Linear(64 * 4 * 4, 256),
+    MixtureReLU(),
+    Linear(256, 128),
+    MixtureReLU(),
+    Linear(128, 11),
+)
+
+TAGI_FNN = Sequential(
+    Linear(32 * 32 * 3, 4096),
+    ReLU(),
+    Linear(4096, 4096),
+    ReLU(),
+    Linear(4096, 11),
+)
+
+
+# TORCH
+def initialize_weights(module):
+    if isinstance(module, nn.Conv2d):
+        nn.init.kaiming_normal_(module.weight, nonlinearity="relu")
+        if module.bias is not None:
+            nn.init.constant_(module.bias, 0)
+    elif isinstance(module, nn.Linear):
+        nn.init.xavier_normal_(module.weight)
+        if module.bias is not None:
+            nn.init.constant_(module.bias, 0)
+
+
+class TorchCNN(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.model = nn.Sequential(
+            # 32x32
+            nn.Conv2d(3, 32, kernel_size=5, padding=2, bias=False),
+            # nn.BatchNorm2d(32),
+            nn.ReLU(),
+            nn.AvgPool2d(kernel_size=2, stride=2),
+            # 16x16
+            nn.Conv2d(32, 32, kernel_size=5, bias=False, padding=2),
+            # nn.BatchNorm2d(32),
+            nn.ReLU(),
+            nn.AvgPool2d(kernel_size=2, stride=2),
+            # 8x8
+            nn.Conv2d(32, 64, kernel_size=5, bias=False, padding=2),
+            # nn.BatchNorm2d(64),
+            nn.ReLU(),
+            nn.AvgPool2d(kernel_size=2, stride=2),
+            # 4x4
+            nn.Flatten(),
+            nn.Linear(64 * 4 * 4, 256),
+            nn.ReLU(),
+            nn.Linear(256, 128),
+            nn.ReLU(),
+            nn.Linear(128, 10),
+        )
+        self.model.apply(initialize_weights)
+
+    def forward(self, x):
+        # for i, layer in enumerate(self.model):
+        #     x = layer(x)
+        #     print(f"Layer {i}: {layer.__class__.__name__}, Output shape {x.shape}")
+        # return x
+        return self.model(x)
+
+
+class TorchFNN(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.model = nn.Sequential(
+            nn.Linear(32 * 32 * 3, 4096),
+            nn.ReLU(),
+            nn.Linear(4096, 4096),
+            nn.ReLU(),
+            nn.Linear(4096, 10),
+        )
+        self.model.apply(initialize_weights)
+
+    def forward(self, x):
+        x = x.view(x.size(0), -1)
+        return self.model(x)
 
 
 def custom_collate_fn(batch):
@@ -42,17 +157,23 @@ def load_datasets(batch_size: int, framework: str = "tagi"):
     """Load and transform CIFAR10 training and test datasets."""
     transform_train = transforms.Compose(
         [
-            transforms.RandomCrop(32, padding=4),
-            transforms.RandomHorizontalFlip(),
-            transforms.ToTensor(),
-            transforms.Normalize(NORMALIZATION_MEAN, NORMALIZATION_STD),
+            transforms.RandomCrop(32, padding=4, padding_mode="reflect"),
+            transforms.RandomHorizontalFlip(p=0.5),
+            # transforms.AugMix(severity=3, mixture_width=3, chain_depth=1, alpha=1.0),
+            # transforms.RandomRotation(degrees=15),
+            # transforms.RandomAffine(degrees=0, translate=(0.1, 0.1)),
+            # transforms.RandomPerspective(distortion_scale=0.2, p=0.5),
+            transforms.ToImage(),
+            transforms.ConvertImageDtype(torch.float32),
+            transforms.Normalize(mean=NORMALIZATION_MEAN, std=NORMALIZATION_STD),
         ]
     )
 
     transform_test = transforms.Compose(
         [
-            transforms.ToTensor(),
-            transforms.Normalize(NORMALIZATION_MEAN, NORMALIZATION_STD),
+            transforms.ToImage(),
+            transforms.ConvertImageDtype(torch.float32),
+            transforms.Normalize(mean=NORMALIZATION_MEAN, std=NORMALIZATION_STD),
         ]
     )
 
@@ -89,10 +210,10 @@ def load_datasets(batch_size: int, framework: str = "tagi"):
 
 
 def tagi_trainer(
-    num_epochs: int = 10,
-    batch_size: int = 128,
-    device: str = "cuda",
-    sigma_v: float = 1.0,
+    num_epochs: int,
+    batch_size: int,
+    device: str,
+    sigma_v: float,
 ):
     """
     Run classification training on the Cifar dataset using a custom neural model.
@@ -108,23 +229,28 @@ def tagi_trainer(
     metric = HRCSoftmaxMetric(num_classes=10)
 
     # Resnet18
-    net = resnet18_cifar10()
+    net = TAGI_CNN_NET
+    # net = resnet18_cifar10()
     net.to_device(device)
+    # net.set_threads(10)
     out_updater = OutputUpdater(net.device)
 
     # Training
-    error_rates = []
+
     var_y = np.full(
         (batch_size * metric.hrc_softmax.num_obs,), sigma_v**2, dtype=np.float32
     )
     pbar = tqdm(range(num_epochs), desc="Training Progress")
     for epoch in pbar:
-        if epoch > 1:
+        error_rates = []
+        if epoch > 0:
             sigma_v = exponential_scheduler(
-                curr_v=sigma_v, min_v=0.3, decaying_factor=0.99, curr_iter=epoch
+                curr_v=sigma_v, min_v=0.2, decaying_factor=0.95, curr_iter=epoch
             )
             var_y = np.full(
-                (batch_size * metric.hrc_softmax.num_obs,), sigma_v**2, dtype=np.float32
+                (batch_size * metric.hrc_softmax.num_obs,),
+                sigma_v**2,
+                dtype=np.float32,
             )
         net.train()
         for x, labels in train_loader:
@@ -156,7 +282,6 @@ def tagi_trainer(
         test_error_rates = []
         net.eval()
         for x, labels in test_loader:
-
             m_pred, v_pred = net(x)
 
             # Training metric
@@ -173,9 +298,9 @@ def tagi_trainer(
 
 def torch_trainer(batch_size: int, num_epochs: int, device: str = "cuda"):
     # Hyperparameters
-    learning_rate = 0.01
+    learning_rate = 0.001
 
-    torch.set_float32_matmul_precision("high")
+    # torch.set_float32_matmul_precision("high")
     train_loader, test_loader = load_datasets(batch_size, "torch")
 
     # Initialize the model, loss function, and optimizer
@@ -185,6 +310,7 @@ def torch_trainer(batch_size: int, num_epochs: int, device: str = "cuda"):
             "CUDA is not available. Please check your CUDA installation."
         )
     model = ResNet18()
+    # model = TorchCNN()
     # model = torch.compile(model)
     model.to(torch_device)
 
@@ -193,9 +319,9 @@ def torch_trainer(batch_size: int, num_epochs: int, device: str = "cuda"):
 
     # Training loop
     pbar = tqdm(range(num_epochs), desc="Training Progress")
-    error_rates = []
     for epoch in pbar:
         model.train()
+        error_rates = []
         for _, (data, target) in enumerate(train_loader):
             data = data.to(torch_device)
             target = target.to(torch_device)
@@ -218,6 +344,7 @@ def torch_trainer(batch_size: int, num_epochs: int, device: str = "cuda"):
         model.eval()
         test_loss = 0
         correct = 0
+        sample_count = 0
         with torch.no_grad():
             for data, target in test_loader:
                 data = data.to(torch_device)
@@ -227,24 +354,28 @@ def torch_trainer(batch_size: int, num_epochs: int, device: str = "cuda"):
                 test_loss += criterion(output, target).item()
                 pred = output.argmax(dim=1, keepdim=True)
                 correct += pred.eq(target.view_as(pred)).sum().item()
+                sample_count += data.shape[0]
 
         test_loss /= len(test_loader.dataset)
         test_error_rate = (1.0 - correct / len(test_loader.dataset)) * 100
         pbar.set_description(
-            f"Epoch# {epoch +1}/{num_epochs}| training error: {avg_error_rate:.2f}% | Test error: {test_error_rate: .2f}%"
+            f"Epoch# {epoch +1}/{num_epochs}| training error: {avg_error_rate:.2f}% | Test error: {test_error_rate: .2f}% | Test sample count: {sample_count}",
         )
 
 
 def main(
     framework: str = "tagi",
     batch_size: int = 128,
-    epochs: int = 40,
+    epochs: int = 100,
     device: str = "cuda",
+    sigma_v: float = 1.0,
 ):
     if framework == "torch":
         torch_trainer(batch_size=batch_size, num_epochs=epochs, device=device)
     elif framework == "tagi":
-        tagi_trainer(batch_size=batch_size, num_epochs=epochs, device=device)
+        tagi_trainer(
+            batch_size=batch_size, num_epochs=epochs, device=device, sigma_v=sigma_v
+        )
     else:
         raise RuntimeError(f"Invalid Framework: {framework}")
 

--- a/examples/cifar_resnet_bench.py
+++ b/examples/cifar_resnet_bench.py
@@ -38,19 +38,19 @@ NORMALIZATION_STD = [0.2470, 0.2435, 0.2616]
 
 TAGI_CNN_NET = Sequential(
     # 32x32
-    Conv2d(3, 32, 5, bias=True, padding=2, in_width=32, in_height=32),
-    # BatchNorm2d(32),
+    Conv2d(3, 32, 5, bias=False, padding=2, in_width=32, in_height=32),
     MixtureReLU(),
+    BatchNorm2d(32),
     AvgPool2d(2, 2),
     # 16x16
-    Conv2d(32, 32, 5, bias=True, padding=2),
-    # BatchNorm2d(32),
+    Conv2d(32, 32, 5, bias=False, padding=2),
     MixtureReLU(),
+    BatchNorm2d(32),
     AvgPool2d(2, 2),
     # 8x8
-    Conv2d(32, 64, 5, bias=True, padding=2),
-    # BatchNorm2d(64),
+    Conv2d(32, 64, 5, bias=False, padding=2),
     MixtureReLU(),
+    BatchNorm2d(64),
     AvgPool2d(2, 2),
     # 4x4
     Linear(64 * 4 * 4, 256),
@@ -229,8 +229,8 @@ def tagi_trainer(
     metric = HRCSoftmaxMetric(num_classes=10)
 
     # Resnet18
-    net = TAGI_CNN_NET
-    # net = resnet18_cifar10()
+    # net = TAGI_CNN_NET
+    net = resnet18_cifar10()
     net.to_device(device)
     # net.set_threads(10)
     out_updater = OutputUpdater(net.device)

--- a/examples/cifar_resnet_bench.py
+++ b/examples/cifar_resnet_bench.py
@@ -229,8 +229,8 @@ def tagi_trainer(
     metric = HRCSoftmaxMetric(num_classes=10)
 
     # Resnet18
-    # net = TAGI_CNN_NET
-    net = resnet18_cifar10()
+    net = TAGI_CNN_NET
+    # net = resnet18_cifar10()
     net.to_device(device)
     # net.set_threads(10)
     out_updater = OutputUpdater(net.device)

--- a/examples/mnist_bench.py
+++ b/examples/mnist_bench.py
@@ -228,7 +228,6 @@ def tagi_trainer(
         test_error_rates = []
         net.eval()
         for x, labels in test_loader:
-
             m_pred, v_pred = net(x)
 
             # Training metric

--- a/examples/regression_heteros.py
+++ b/examples/regression_heteros.py
@@ -53,7 +53,6 @@ def main(num_epochs: int = 50, batch_size: int = 10):
         )
         net.set_threads(8)
 
-
     out_updater = OutputUpdater(net.device)
 
     # -------------------------------------------------------------------------#

--- a/examples/resnet18_cifar10.py
+++ b/examples/resnet18_cifar10.py
@@ -141,7 +141,9 @@ def main(num_epochs: int = 100, batch_size: int = 128, sigma_v: float = 1):
                 curr_v=sigma_v, min_v=0.3, decaying_factor=0.95, curr_iter=epoch
             )
             var_y = np.full(
-                (batch_size * metric.hrc_softmax.num_obs,), sigma_v**2, dtype=np.float32
+                (batch_size * metric.hrc_softmax.num_obs,),
+                sigma_v**2,
+                dtype=np.float32,
             )
         net.train()
         for x, labels in train_loader:
@@ -173,7 +175,6 @@ def main(num_epochs: int = 100, batch_size: int = 128, sigma_v: float = 1):
         test_error_rates = []
         net.eval()
         for x, labels in test_loader:
-
             m_pred, v_pred = net(x)
 
             # Training metric

--- a/examples/time_series_forecasting.py
+++ b/examples/time_series_forecasting.py
@@ -280,7 +280,15 @@ class PredictionViz:
         if eq is not None:
             ax.text(x_eq, y_eq, eq, color="k", fontsize=self.fontsize)
         ax.plot(x_test, y_pred, "r", lw=self.lw, label=r"$\mathbb{E}[Y^{'}]$")
-        ax.plot(x_test, y_test, "k", lw=self.lw, label=r"$y_{true}$", marker=marker, linestyle=line_style)
+        ax.plot(
+            x_test,
+            y_test,
+            "k",
+            lw=self.lw,
+            label=r"$y_{true}$",
+            marker=marker,
+            linestyle=line_style,
+        )
 
         ax.fill_between(
             x_test,

--- a/pytagi/nn/activation.py
+++ b/pytagi/nn/activation.py
@@ -119,6 +119,7 @@ class Softmax(BaseLayer):
     def get_layer_name(self) -> str:
         return self._cpp_backend.get_layer_name()
 
+
 class EvenExp(BaseLayer):
     """EvenExp"""
 

--- a/pytagi/nn/output_updater.py
+++ b/pytagi/nn/output_updater.py
@@ -41,9 +41,7 @@ class OutputUpdater:
         mu_obs: np.ndarray,
         delta_states: BaseDeltaStates,
     ):
-        self._cpp_backend.update_heteros(
-            output_states, mu_obs.tolist(), delta_states
-        )
+        self._cpp_backend.update_heteros(output_states, mu_obs.tolist(), delta_states)
 
     @property
     def device(self) -> str:

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -349,8 +349,8 @@ float normpdf_cpu(float x, float mu, float sigma)
     if (sigma < 0.0f) {
         throw std::invalid_argument("Sigma value is negative");
     }
-    float pi = 3.141592;  // pi number
-    float prob_pdf = (1 / (sigma * pow(2 * pi, 0.5))) *
+    const float PI = 3.14159265358979323846f;
+    float prob_pdf = (1 / (sigma * pow(2 * PI, 0.5))) *
                      exp(-pow(x - mu, 2) / (2 * pow(sigma, 2)));
 
     return prob_pdf;

--- a/src/lstm_layer_cuda.cu
+++ b/src/lstm_layer_cuda.cu
@@ -124,7 +124,7 @@ Args:
         Sc[k] = Sc_prev[k] * mf_ga[k] * mf_ga[k] + Sc_prev[k] * Sf_ga[k] +
                 Sf_ga[k] * mc_prev[k] * mc_prev[k] +
                 Sc_ga[k] * mi_ga[k] * mi_ga[k] + Si_ga[k] * Sc_ga[k] +
-                Si_ga[k] * mc_ga[k] * mc_ga[k] + powf(Ci_c[k], 2) +
+                Si_ga[k] * mc_ga[k] * mc_ga[k] + Ci_c[k] * Ci_c[k] +
                 2 * Ci_c[k] * mi_ga[k] * mc_ga[k];
     }
 }
@@ -215,7 +215,7 @@ Args:
 
         mz[k] = mo_ga[j] * mc_a[j] + Co_tanh_c[j];
         Sz[k] = Sc_a[j] * mo_ga[j] * mo_ga[j] + Sc_a[j] * So_ga[j] +
-                So_ga[j] * mc_a[j] * mc_a[j] + powf(Co_tanh_c[j], 2) +
+                So_ga[j] * mc_a[j] * mc_a[j] + Co_tanh_c[j] * Co_tanh_c[j] +
                 2 * Co_tanh_c[j] * mo_ga[j] * mc_a[j];
     }
 }
@@ -329,7 +329,8 @@ NOTE: All LSTM states excepted mc_prev are from the next layer e.g., mi_ga(l+1)
             // Output gate
             Czz_o = Jo_ga[k] * mw[(ni + no) * j + col + w_pos_o] * mca[k];
             sum_mo += Czz_o * delta_m_out[i];
-            sum_Sz += powf(Czz_f + Czz_i + Czz_c + Czz_o, 2) * delta_S_out[i];
+            float tmp_sum_cov = Czz_f + Czz_i + Czz_c + Czz_o;
+            sum_Sz += tmp_sum_cov * tmp_sum_cov * delta_S_out[i];
         }
 
         // Updating quantities

--- a/test/resnet/test_resnet_cifar10.cpp
+++ b/test/resnet/test_resnet_cifar10.cpp
@@ -117,17 +117,18 @@ void resnet_cifar10()
         block_7, LayerBlock(Conv2d(256, 512, 2, false, 2), BatchNorm2d(512)));
     ResNetBlock resnet_block_8(block_8);
 
-    Sequential model(
-        // Input block
-        Conv2d(3, 64, 3, false, 1, 1, 1, 32, 32), BatchNorm2d(64), ReLU(),
+    // Sequential model(
+    //     // Input block
+    //     Conv2d(3, 64, 3, false, 1, 1, 1, 32, 32), BatchNorm2d(64), ReLU(),
 
-        // Residual blocks
-        resnet_block_1, ReLU(), resnet_block_2, ReLU(), resnet_block_3, ReLU(),
-        resnet_block_4, ReLU(), resnet_block_5, ReLU(), resnet_block_6, ReLU(),
-        resnet_block_7, ReLU(), resnet_block_8, ReLU(),
+    //     // Residual blocks
+    //     resnet_block_1, ReLU(), resnet_block_2, ReLU(), resnet_block_3,
+    //     ReLU(), resnet_block_4, ReLU(), resnet_block_5, ReLU(),
+    //     resnet_block_6, ReLU(), resnet_block_7, ReLU(), resnet_block_8,
+    //     ReLU(),
 
-        // Output block
-        AvgPool2d(4), Linear(512, 11));
+    //     // Output block
+    //     AvgPool2d(4), Linear(512, 11));
 
     // auto block_1 = create_layer_block(8, 8);
     // auto block_2 = create_layer_block(8, 8);
@@ -166,20 +167,19 @@ void resnet_cifar10()
     //     // Output block
     //     AvgPool2d(4), Linear(64, 11));
 
-    // Sequential model(Conv2d(3, 32, 5, false, 1, 2, 1, 32, 32),
-    // BatchNorm2d(32),
-    //                  ReLU(), AvgPool2d(3, 2, 1, 2),
-    //                  Conv2d(32, 32, 5, false, 1, 2, 1), BatchNorm2d(32),
-    //                  ReLU(), AvgPool2d(3, 2, 1, 2), Conv2d(32, 64, 5, false,
-    //                  1, 2, 1), BatchNorm2d(64), ReLU(), AvgPool2d(3, 2, 1,
-    //                  2), Linear(64 * 4 * 4, 100), ReLU(), Linear(100, 11));
+    Sequential model(Conv2d(3, 32, 5, true, 1, 2, 1, 32, 32), MixtureReLU(),
+                     AvgPool2d(3, 2, 1, 2), Conv2d(32, 32, 5, true, 1, 2, 1),
+                     MixtureReLU(), AvgPool2d(3, 2, 1, 2),
+                     Conv2d(32, 64, 5, true, 1, 2, 1), MixtureReLU(),
+                     AvgPool2d(3, 2, 1, 2), Linear(64 * 4 * 4, 100),
+                     MixtureReLU(), Linear(100, 11));
 
     // model.set_threads(1);
     // model.preinit_layer();
     // model.save("test_model/resnet.bin");
     model.to_device("cuda");
 
-    // model.load("test_model/resnet.bin");
+    model.load("test_model/resnet.bin");
 
     OutputUpdater output_updater(model.device);
 


### PR DESCRIPTION
## Description

This PR fixes bugs in the mReLU activation function for cuda version

## Changes Made
- Removed the unnecessary usage of `powf` in pdf calculation and in other functions in code base
- Replaced cuda built-in `normcdff` by a custom function because it causes the issue too

## Note for Reviewers
Here is the command to run the test with `MixtureReLU`
```shell
python -m examples.cifar_resnet_bench
```