### PR TITLE
Bugs in Heteros Update

### DIFF
--- a/examples/regression_heteros.py
+++ b/examples/regression_heteros.py
@@ -33,24 +33,13 @@ def main(num_epochs: int = 50, batch_size: int = 10):
     viz = PredictionViz(task_name="heteros regression", data_name="1d_toy_noise")
 
     cuda = True
-
+    net = Sequential(
+        Linear(1, 128), ReLU(), Linear(128, 128), ReLU(), Linear(128, 2), EvenExp()
+    )
     if cuda:
-        net = Sequential(
-            Linear(1, 128), ReLU(), Linear(128, 128), ReLU(), Linear(128, 2), EvenExp()
-        )
         net.to_device("cuda")
     else:
-        # Network
-        net = Sequential(
-            Linear(1, 128),
-            ReLU(),
-            Linear(128, 128),
-            ReLU(),
-            Linear(128, 2),
-            EvenExp(),
-        )
         net.set_threads(8)
-
     out_updater = OutputUpdater(net.device)
 
     # -------------------------------------------------------------------------#

--- a/src/activation_cuda.cu
+++ b/src/activation_cuda.cu
@@ -693,8 +693,6 @@ void EvenExpCuda::forward(BaseHiddenStates &input_states,
         dynamic_cast<HiddenStateCuda *>(&input_states);
     HiddenStateCuda *cu_output_states =
         dynamic_cast<HiddenStateCuda *>(&output_states);
-    // TempStateCuda *cu_temp_states = dynamic_cast<TempStateCuda
-    // *>(&temp_states);
 
     int num_states = input_states.actual_size * input_states.block_size;
     unsigned int blocks =

--- a/test/heteros/test_fnn_heteros_cpu_v2.cpp
+++ b/test/heteros/test_fnn_heteros_cpu_v2.cpp
@@ -49,13 +49,14 @@ void fnn_heteros_v2()
                                   train_db.sigma_y, 51, n_x, n_y, true);
 
     Sequential model(Linear(13, 50), ReLU(), Linear(50, 2), EvenExp());
-    model.set_threads(8);
+    model.set_threads(1);
+    // model.to_device("cuda");
 
     //////////////////////////////////////////////////////////////////////
     // Training
     //////////////////////////////////////////////////////////////////////
 
-    int batch_size = 10;
+    int batch_size = 2;
     int iters = train_db.num_data / batch_size;
     std::vector<float> x_batch(batch_size * n_x, 0.0f);
     std::vector<float> y_batch(batch_size * n_y, 0.0f);
@@ -84,6 +85,12 @@ void fnn_heteros_v2()
             // Backward pass
             model.backward();
             model.step();
+
+            // Extract output
+            if (model.device == "cuda") {
+                model.output_to_host();
+            }
+            int check = 1;
         }
     }
 


### PR DESCRIPTION
## Description

This PR fixes bug in the heteroscedatic updating for cuda version.

## Changes Made
- Adapted `update_delta_z_cuda_heteros(...)` for the observation size
- Added `EvenExp()` for cuda version
- Refactored Python examples

## Notes for Reviewers
- For the cuda version, I kept the size of the observation as it is but I changed the kernel  `update_delta_z_cuda_heteros(...)`  accordingly
- For a quick test, you should enable two modes cuda (current) and cpu 
```shell
python -m examples.regression_heteros
```