### PR TITLE
Correct errors & bugs in norm_layer*

### DIFF
--- a/examples/cifar_resnet_bench.py
+++ b/examples/cifar_resnet_bench.py
@@ -362,7 +362,7 @@ def torch_trainer(batch_size: int, num_epochs: int, device: str = "cuda"):
 def main(
     framework: str = "tagi",
     batch_size: int = 128,
-    epochs: int = 100,
+    epochs: int = 3,
     device: str = "cuda",
     sigma_v: float = 1.0,
 ):

--- a/examples/cifar_resnet_bench.py
+++ b/examples/cifar_resnet_bench.py
@@ -39,18 +39,18 @@ NORMALIZATION_STD = [0.2470, 0.2435, 0.2616]
 TAGI_CNN_NET = Sequential(
     # 32x32
     Conv2d(3, 32, 5, bias=False, padding=2, in_width=32, in_height=32),
-    MixtureReLU(),
     BatchNorm2d(32),
+    MixtureReLU(),
     AvgPool2d(2, 2),
     # 16x16
     Conv2d(32, 32, 5, bias=False, padding=2),
-    MixtureReLU(),
     BatchNorm2d(32),
+    MixtureReLU(),
     AvgPool2d(2, 2),
     # 8x8
     Conv2d(32, 64, 5, bias=False, padding=2),
-    MixtureReLU(),
     BatchNorm2d(64),
+    MixtureReLU(),
     AvgPool2d(2, 2),
     # 4x4
     Linear(64 * 4 * 4, 256),
@@ -241,7 +241,7 @@ def tagi_trainer(
         error_rates = []
         if epoch > 0:
             sigma_v = exponential_scheduler(
-                curr_v=sigma_v, min_v=0.2, decaying_factor=0.99, curr_iter=epoch
+                curr_v=sigma_v, min_v=0.01, decaying_factor=0.8, curr_iter=epoch
             )
             var_y = np.full(
                 (batch_size * metric.hrc_softmax.num_obs,),
@@ -355,16 +355,17 @@ def torch_trainer(batch_size: int, num_epochs: int, device: str = "cuda"):
         test_loss /= len(test_loader.dataset)
         test_error_rate = (1.0 - correct / len(test_loader.dataset)) * 100
         pbar.set_description(
-            f"Epoch# {epoch +1}/{num_epochs}| training error: {avg_error_rate:.2f}% | Test error: {test_error_rate: .2f}% | Test sample count: {sample_count}",
+            f"Epoch# {epoch +1}/{num_epochs}| training error: {avg_error_rate:.2f}% | Test error: {test_error_rate: .2f}%\n",
+            refresh=False,
         )
 
 
 def main(
     framework: str = "tagi",
-    batch_size: int = 128,
+    batch_size: int = 1,
     epochs: int = 50,
     device: str = "cuda",
-    sigma_v: float = 1.0,
+    sigma_v: float = 0.1,
 ):
     if framework == "torch":
         torch_trainer(batch_size=batch_size, num_epochs=epochs, device=device)

--- a/examples/cifar_resnet_bench.py
+++ b/examples/cifar_resnet_bench.py
@@ -362,7 +362,7 @@ def torch_trainer(batch_size: int, num_epochs: int, device: str = "cuda"):
 def main(
     framework: str = "tagi",
     batch_size: int = 128,
-    epochs: int = 3,
+    epochs: int = 50,
     device: str = "cuda",
     sigma_v: float = 1.0,
 ):

--- a/examples/cifar_resnet_bench.py
+++ b/examples/cifar_resnet_bench.py
@@ -286,8 +286,8 @@ def tagi_trainer(
 
         test_error_rate = sum(test_error_rates) / len(test_error_rates)
         pbar.set_description(
-            f"Epoch {epoch + 1}/{num_epochs} | training error: {avg_error_rate:.2f}% | test error: {test_error_rate * 100:.2f}%",
-            refresh=True,
+            f"Epoch {epoch + 1}/{num_epochs} | training error: {avg_error_rate:.2f}% | test error: {test_error_rate * 100:.2f}\n%",
+            refresh=False,
         )
     print("Training complete.")
 

--- a/examples/cifar_resnet_bench.py
+++ b/examples/cifar_resnet_bench.py
@@ -362,7 +362,7 @@ def torch_trainer(batch_size: int, num_epochs: int, device: str = "cuda"):
 
 def main(
     framework: str = "tagi",
-    batch_size: int = 256,
+    batch_size: int = 128,
     epochs: int = 50,
     device: str = "cuda",
     sigma_v: float = 1,

--- a/examples/cifar_resnet_bench.py
+++ b/examples/cifar_resnet_bench.py
@@ -241,7 +241,7 @@ def tagi_trainer(
         error_rates = []
         if epoch > 0:
             sigma_v = exponential_scheduler(
-                curr_v=sigma_v, min_v=0.01, decaying_factor=0.8, curr_iter=epoch
+                curr_v=sigma_v, min_v=0.2, decaying_factor=0.99, curr_iter=epoch
             )
             var_y = np.full(
                 (batch_size * metric.hrc_softmax.num_obs,),
@@ -362,10 +362,10 @@ def torch_trainer(batch_size: int, num_epochs: int, device: str = "cuda"):
 
 def main(
     framework: str = "tagi",
-    batch_size: int = 1,
+    batch_size: int = 256,
     epochs: int = 50,
     device: str = "cuda",
-    sigma_v: float = 0.1,
+    sigma_v: float = 1,
 ):
     if framework == "torch":
         torch_trainer(batch_size=batch_size, num_epochs=epochs, device=device)

--- a/examples/classification.py
+++ b/examples/classification.py
@@ -16,11 +16,11 @@ from pytagi.nn import (
 )
 
 FNN = Sequential(
-    Linear(784, 32),
+    Linear(784, 128),
     ReLU(),
-    Linear(32, 32),
+    Linear(128, 128),
     ReLU(),
-    Linear(32, 11),
+    Linear(128, 11),
 )
 
 FNN_BATCHNORM = Sequential(

--- a/examples/classification.py
+++ b/examples/classification.py
@@ -24,23 +24,23 @@ FNN = Sequential(
 )
 
 FNN_BATCHNORM = Sequential(
-    Linear(784, 16),
+    Linear(784, 32),
     ReLU(),
-    BatchNorm2d(16),
-    Linear(16, 16),
+    BatchNorm2d(32),
+    Linear(32,32),
     ReLU(),
-    BatchNorm2d(16),
-    Linear(16, 11),
+    BatchNorm2d(32),
+    Linear(32, 11),
 )
 
 FNN_LAYERNORM = Sequential(
-    Linear(784, 128, bias=False),
+    Linear(784, 32, bias=False),
     ReLU(),
-    LayerNorm((128,)),
-    Linear(128, 128, bias=False),
+    LayerNorm((32,)),
+    Linear(32, 32, bias=False),
     ReLU(),
-    LayerNorm((128,)),
-    Linear(128, 11),
+    LayerNorm((32,)),
+    Linear(32, 11),
 )
 
 CNN = Sequential(
@@ -84,7 +84,7 @@ CNN_LAYERNORM = Sequential(
 )
 
 
-def main(num_epochs: int = 10, batch_size: int = 256, sigma_v: float = 2.0):
+def main(num_epochs: int = 10, batch_size: int = 48, sigma_v: float = 2.0):
     """
     Run classification training on the MNIST dataset using a custom neural model.
 

--- a/examples/classification.py
+++ b/examples/classification.py
@@ -16,31 +16,31 @@ from pytagi.nn import (
 )
 
 FNN = Sequential(
-    Linear(784, 128),
+    Linear(784, 32),
     ReLU(),
-    Linear(128, 128),
+    Linear(32, 32),
     ReLU(),
-    Linear(128, 11),
+    Linear(32, 11),
 )
 
 FNN_BATCHNORM = Sequential(
-    Linear(784, 100),
+    Linear(784, 16),
     ReLU(),
-    BatchNorm2d(100),
-    Linear(100, 100),
+    BatchNorm2d(16),
+    Linear(16, 16),
     ReLU(),
-    BatchNorm2d(100),
-    Linear(100, 11),
+    BatchNorm2d(16),
+    Linear(16, 11),
 )
 
 FNN_LAYERNORM = Sequential(
-    Linear(784, 100, bias=False),
+    Linear(784, 128, bias=False),
     ReLU(),
-    LayerNorm((100,)),
-    Linear(100, 100, bias=False),
+    LayerNorm((128,)),
+    Linear(128, 128, bias=False),
     ReLU(),
-    LayerNorm((100,)),
-    Linear(100, 11),
+    LayerNorm((128,)),
+    Linear(128, 11),
 )
 
 CNN = Sequential(
@@ -108,7 +108,7 @@ def main(num_epochs: int = 10, batch_size: int = 256, sigma_v: float = 2.0):
     metric = HRCSoftmaxMetric(num_classes=10)
 
     # Network configuration
-    net = CNN_LAYERNORM
+    net = FNN_BATCHNORM
     net.to_device("cpu")
     net.set_threads(48)
     out_updater = OutputUpdater(net.device)
@@ -157,8 +157,8 @@ def main(num_epochs: int = 10, batch_size: int = 256, sigma_v: float = 2.0):
 
         test_error_rate = sum(test_error_rates) / len(test_error_rates)
         pbar.set_description(
-            f"Epoch {epoch + 1}/{num_epochs} | training error: {avg_error_rate:.2f}% | test error: {test_error_rate * 100:.2f}%",
-            refresh=True,
+            f"Epoch {epoch + 1}/{num_epochs} | training error: {avg_error_rate:.2f}% | test error: {test_error_rate * 100:.2f}%\n",
+            refresh=False,
         )
     print("Training complete.")
 

--- a/examples/classification.py
+++ b/examples/classification.py
@@ -108,9 +108,9 @@ def main(num_epochs: int = 10, batch_size: int = 256, sigma_v: float = 2.0):
     metric = HRCSoftmaxMetric(num_classes=10)
 
     # Network configuration
-    net = FNN
-    net.to_device("cuda")
-    net.set_threads(16)
+    net = CNN_LAYERNORM
+    net.to_device("cpu")
+    net.set_threads(48)
     out_updater = OutputUpdater(net.device)
 
     # Training

--- a/src/base_layer.cpp
+++ b/src/base_layer.cpp
@@ -179,8 +179,11 @@ Returns:
 */
 {
     // TODO: Heuristic values!!
-    if (batch_size >= 16) {
-        this->cap_factor_update = 1;  // batch_size ;
+    if (batch_size >= 128 && batch_size < 512) {
+        this->cap_factor_update = 10.0f;
+    }
+    if (batch_size >= 512) {
+        this->cap_factor_update = 20.0f;
     }
 }
 

--- a/src/base_layer.cpp
+++ b/src/base_layer.cpp
@@ -139,7 +139,7 @@ void BaseLayer::update_weights()
         this->mu_w[i] +=
             delta_mu_sign * std::min(std::abs(delta_mu_w[i]), delta_bar);
         this->var_w[i] +=
-            delta_var_sign * std::min(std::abs(delta_var_w[i]), delta_bar);
+           delta_var_sign * std::min(std::abs(delta_var_w[i]), delta_bar);
     }
 }
 
@@ -159,8 +159,8 @@ void BaseLayer::update_biases()
             this->mu_b[i] += delta_mu_sign *
                              std::min(std::abs(this->delta_mu_b[i]), delta_bar);
             this->var_b[i] +=
-                delta_var_sign *
-                std::min(std::abs(this->delta_var_b[i]), delta_bar);
+                            delta_var_sign *
+                            std::min(std::abs(this->delta_var_b[i]), delta_bar);
         }
     }
 }
@@ -179,11 +179,8 @@ Returns:
 */
 {
     // TODO: Heuristic values!!
-    if (batch_size >= 128 && batch_size < 512) {
-        this->cap_factor_update = 10.0f;
-    }
-    if (batch_size >= 512) {
-        this->cap_factor_update = 20.0f;
+    if (batch_size >= 16) {
+        this->cap_factor_update = 1;  // batch_size ;
     }
 }
 

--- a/src/norm_layer.cpp
+++ b/src/norm_layer.cpp
@@ -420,7 +420,7 @@ layer is a convolutional layer.
 
         for (int col = 0; col < k; col++)  // k = wihi, m = fi*B
         {
-            int idx = col + row * k
+            int idx = col + row * k;
             float mu_a_tilde = mu_a[idx] - mu_ra_term;
 
             mu_z[idx] = inv_sqrt_var_ra * mu_a_tilde * mu_w_term +

--- a/src/norm_layer.cpp
+++ b/src/norm_layer.cpp
@@ -56,7 +56,8 @@ void layernorm_sample_var(const std::vector<float> &mu_a,
             sum += (mu_a[col * ni + i] - mu_s[col]) *
                    (mu_a[col * ni + i] - mu_s[col]);
         }
-        var_sample[col] = (sum + var_s[col]) / (ni - 1);
+        //var_sample[col] = (sum + var_s[col]) / (ni - 1);
+        var_sample[col] = sum / (ni - 1);
     }
 }
 
@@ -383,8 +384,8 @@ void batchnorm_fwd_mean_var(
                                        + mu_ra[col] * mu_ra[col]
                                         - 2.0f * mu_a[idx] * mu_ra[col]
                                        )
-                )
-                + var_b[col];
+                        )
+                        + var_b[col];
         }
     }
 }

--- a/src/norm_layer.cpp
+++ b/src/norm_layer.cpp
@@ -417,11 +417,11 @@ layer is a convolutional layer.
         float inv_sqrt_var_ra = 1.0f / std::sqrt(var_ra[row % fi] + epsilon);
         float mu_ra_term = mu_ra[row % fi];
         float mu_w_term = mu_w[row % fi];
-        float mu_a_tilde = mu_a[idx] - mu_ra_term;
 
         for (int col = 0; col < k; col++)  // k = wihi, m = fi*B
         {
-            int idx = col + row * k;
+            int idx = col + row * k
+            float mu_a_tilde = mu_a[idx] - mu_ra_term;
 
             mu_z[idx] = inv_sqrt_var_ra * mu_a_tilde * mu_w_term +
                         mu_b[row % fi];

--- a/src/norm_layer.cpp
+++ b/src/norm_layer.cpp
@@ -21,8 +21,7 @@
 void layernorm_stat_mean_var(const std::vector<float> &mu_a,
                              const std::vector<float> &var_a, int ni,
                              int start_chunk, int end_chunk,
-                             std::vector<float> &mu_s,
-                             std::vector<float> &var_s)
+                             std::vector<float> &mu_s)
 /*
  */
 {
@@ -35,13 +34,12 @@ void layernorm_stat_mean_var(const std::vector<float> &mu_a,
             sum_var += var_a[col * ni + i];
         }
         mu_s[col] = sum_mu / ni;
-        var_s[col] = sum_var;
     }
 }
 
 void layernorm_sample_var(const std::vector<float> &mu_a,
                           const std::vector<float> &mu_s,
-                          const std::vector<float> &var_s, int ni,
+                          int ni,
                           int start_chunk, int end_chunk,
                           std::vector<float> &var_sample)
 /*
@@ -56,7 +54,6 @@ void layernorm_sample_var(const std::vector<float> &mu_a,
             sum += (mu_a[col * ni + i] - mu_s[col]) *
                    (mu_a[col * ni + i] - mu_s[col]);
         }
-        //var_sample[col] = (sum + var_s[col]) / (ni - 1);
         var_sample[col] = sum / (ni - 1);
     }
 }
@@ -93,12 +90,6 @@ void layernorm_fwd_mean_var(
             float mu_term = adjusted_mu_a * mu_w[col];
 
             mu_z[index] = inv_sqrt_var_ra * mu_term + mu_b[col];
-            /*var_z[index] =
-                inv_sqrt_var_ra * inv_sqrt_var_ra *
-                    (var_a[index] * mu_w[col] * mu_w[col] +
-                     var_w[col] * (mu_a[index] * mu_a[index] -
-                                   mu_ra_term * mu_ra_term + var_a[index])) +
-                var_b[col];*/
             var_z[index] = inv_sqrt_var_ra * inv_sqrt_var_ra *
                         (var_a[index] * (mu_w[col] * mu_w[col] + var_w[col])
                         + var_w[col] * (mu_a[index] * mu_a[index]
@@ -133,10 +124,6 @@ void layernorm2d_fwd_mean_var(
 
             mu_z[idx] = inv_sqrt_var_ra * (mu_a[idx] - mu_ra_term) * mu_w_term +
                         mu_b[idx_div];
-            /*var_z[idx] = inv_sqrt_var_ra * inv_sqrt_var_ra *
-                             (var_a[idx] * mu_w_term * mu_w_term +
-                              var_w[idx_div] * adjusted_mu_a) +
-                         var_b[idx_div];*/
             var_z[idx] = inv_sqrt_var_ra * inv_sqrt_var_ra *
                         (var_a[idx] * (mu_w_term * mu_w_term + var_w[idx_div])
                         + var_w[idx_div] * (mu_a[idx] * mu_a[idx]
@@ -316,8 +303,7 @@ void delta_param_sum(const std::vector<float> &delta_mu_e,
 void batchnorm_stat_mean_var(const std::vector<float> &mu_a,
                              const std::vector<float> &var_a, int ni,
                              int batch_size, int start_chunk, int end_chunk,
-                             std::vector<float> &mu_s,
-                             std::vector<float> &var_s)
+                             std::vector<float> &mu_s)
 /*Compute sample mean and variance of activation units of full-connected layer
 for each batch.
 */
@@ -331,13 +317,12 @@ for each batch.
             sum_var += var_a[col + i * ni];
         }
         mu_s[col] = sum_mu / batch_size;
-        var_s[col] = sum_var;
     }
 }
 
 void batchnorm_sample_var(const std::vector<float> &mu_a,
                           const std::vector<float> &mu_s,
-                          const std::vector<float> &var_s, int ni,
+                          int ni,
                           int batch_size, int start_chunk, int end_chunk,
                           std::vector<float> &var)
 /*Compute statistical mean and variance of activation units for full-connected
@@ -350,7 +335,6 @@ layer for each batch.
             sum += (mu_a[col + i * ni] - mu_s[col]) *
                    (mu_a[col + i * ni] - mu_s[col]);
         }
-        //var[col] = (sum + var_s[col]) / (batch_size - 1);
         var[col] = sum / (batch_size - 1);
     }
 }
@@ -374,10 +358,6 @@ void batchnorm_fwd_mean_var(
 
             mu_z[idx] = inv_sqrt_var_ra * (mu_a[idx] - mu_ra[col]) * mu_w[col] +
                         mu_b[col];
-            /*var_z[idx] = inv_sqrt_var_ra * inv_sqrt_var_ra *
-                             (var_a[idx] * mu_w[col] * mu_w[col] +
-                              var_w[col] * adjusted_mu_a) +
-                         var_b[col];*/
             var_z[idx] = inv_sqrt_var_ra * inv_sqrt_var_ra *
                         (var_a[idx] * (mu_w[col] * mu_w[col] + var_w[col])
                         + var_w[col] * (mu_a[idx] * mu_a[idx]
@@ -393,8 +373,7 @@ void batchnorm_fwd_mean_var(
 void batchnorm2d_stat_mean_var(const std::vector<float> &mu_a,
                                const std::vector<float> &var_a, int wihi,
                                int fi, int batch_size, int start_chunk,
-                               int end_chunk, std::vector<float> &mu_s,
-                               std::vector<float> &var_s)
+                               int end_chunk, std::vector<float> &mu_s)
 /*Compute sample mean and variance of activation units for batch-normalization
 layer.
 */
@@ -408,13 +387,12 @@ layer.
             sum_var += var_a[(i / wihi) * wihi * fi + i % wihi + col * wihi];
         }
         mu_s[col] = sum_mu / (wihi * batch_size);
-        var_s[col] = sum_var;
     }
 }
 
 void batchnorm2d_sample_var(const std::vector<float> &mu_a,
                             const std::vector<float> &mu_s,
-                            const std::vector<float> &var_s, int wihi, int fi,
+                            int wihi, int fi,
                             int batch_size, int start_chunk, int end_chunk,
                             std::vector<float> &var)
 /*Compute statistical mean and variance of activation units for
@@ -429,7 +407,6 @@ batch-normalization layer.
                    (mu_a[(i / wihi) * wihi * fi + i % wihi + col * wihi] -
                     mu_s[col]);
         }
-        //var[col] = (sum + var_s[col]) / (wihi * batch_size - 1);
         var[col] = sum / (wihi * batch_size - 1);
     }
 }
@@ -459,12 +436,6 @@ layer is a convolutional layer.
             mu_z[idx] = inv_sqrt_var_ra * (mu_a[idx] - mu_ra_term) * mu_w_term +
                         mu_b[row % fi];
 
-            /*var_z[idx] =
-                inv_sqrt_var_ra * inv_sqrt_var_ra *
-                    (var_a[idx] * mu_w_term * mu_w_term +
-                     var_w[row % fi] * (mu_a[idx] * mu_a[idx] -
-                                        mu_ra_term * mu_ra_term + var_a[idx])) +
-                var_b[row % fi];*/
             var_z[idx] = inv_sqrt_var_ra * inv_sqrt_var_ra *
                 (var_a[idx] * (mu_w_term * mu_w_term + var_w[row % fi])
                 + var_w[row % fi] * (mu_a[idx] * mu_a[idx]
@@ -648,7 +619,7 @@ void layernorm_stat_mean_var_mp(const std::vector<float> &mu_a,
 
         threads.emplace_back([=, &mu_a, &var_a, &mu_s, &var_s] {
             layernorm_stat_mean_var(mu_a, var_a, ni, start_chunk, end_chunk,
-                                    mu_s, var_s);
+                                    mu_s);
         });
     }
 
@@ -661,7 +632,7 @@ void layernorm_stat_mean_var_mp(const std::vector<float> &mu_a,
 
 void layernorm_sample_var_mp(const std::vector<float> &mu_a,
                              const std::vector<float> &mu_s,
-                             const std::vector<float> &var_s, int ni,
+                             int ni,
                              int batch_size, const int num_threads,
                              std::vector<float> &var_sample)
 /*
@@ -677,8 +648,8 @@ void layernorm_sample_var_mp(const std::vector<float> &mu_a,
         int start_chunk = i * n_per_thread + std::min(i, extra);
         int end_chunk = start_chunk + n_per_thread + (i < extra ? 1 : 0);
 
-        threads.emplace_back([=, &mu_a, &mu_s, &var_s, &var_sample] {
-            layernorm_sample_var(mu_a, mu_s, var_s, ni, start_chunk, end_chunk,
+        threads.emplace_back([=, &mu_a, &mu_s, &var_sample] {
+            layernorm_sample_var(mu_a, mu_s, ni, start_chunk, end_chunk,
                                  var_sample);
         });
     }
@@ -1012,8 +983,7 @@ void delta_param_sum_mp(const std::vector<float> delta_mu_e,
 void batchnorm_stat_mean_var_mp(const std::vector<float> &mu_a,
                                 const std::vector<float> &var_a, int ni,
                                 int batch_size, const int num_threads,
-                                std::vector<float> &mu_s,
-                                std::vector<float> &var_s)
+                                std::vector<float> &mu_s)
 /*Compute sample mean and variance of activation units of full-connected layer
 for each batch.
 */
@@ -1028,9 +998,9 @@ for each batch.
         int start_chunk = i * n_per_thread + std::min(i, extra);
         int end_chunk = start_chunk + n_per_thread + (i < extra ? 1 : 0);
 
-        threads.emplace_back([=, &mu_a, &var_a, &mu_s, &var_s] {
+        threads.emplace_back([=, &mu_a, &var_a, &mu_s] {
             batchnorm_stat_mean_var(mu_a, var_a, ni, batch_size, start_chunk,
-                                    end_chunk, mu_s, var_s);
+                                    end_chunk, mu_s);
         });
     }
 
@@ -1043,7 +1013,7 @@ for each batch.
 
 void batchnorm_sample_var_mp(const std::vector<float> &mu_a,
                              const std::vector<float> &mu_s,
-                             const std::vector<float> &var_s, int ni,
+                             int ni,
                              int batch_size, const int num_threads,
                              std::vector<float> &var)
 /*
@@ -1059,8 +1029,8 @@ void batchnorm_sample_var_mp(const std::vector<float> &mu_a,
         int start_chunk = i * n_per_thread + std::min(i, extra);
         int end_chunk = start_chunk + n_per_thread + (i < extra ? 1 : 0);
 
-        threads.emplace_back([=, &mu_a, &mu_s, &var_s, &var] {
-            batchnorm_sample_var(mu_a, mu_s, var_s, ni, batch_size, start_chunk,
+        threads.emplace_back([=, &mu_a, &mu_s, &var] {
+            batchnorm_sample_var(mu_a, mu_s, ni, batch_size, start_chunk,
                                  end_chunk, var);
         });
     }
@@ -1110,8 +1080,7 @@ void batchnorm_fwd_mean_var_mp(
 void batchnorm2d_stat_mean_var_mp(const std::vector<float> &mu_a,
                                   const std::vector<float> &var_a, int wihi,
                                   int fi, int batch_size, const int num_threads,
-                                  std::vector<float> &mu_s,
-                                  std::vector<float> &var_s)
+                                  std::vector<float> &mu_s)
 /*Compute sample mean and variance of activation units for batch-normalization
 layer.
 */
@@ -1126,9 +1095,9 @@ layer.
         int start_chunk = i * n_per_thread + std::min(i, extra);
         int end_chunk = start_chunk + n_per_thread + (i < extra ? 1 : 0);
 
-        threads.emplace_back([=, &mu_a, &var_a, &mu_s, &var_s] {
+        threads.emplace_back([=, &mu_a, &var_a, &mu_s] {
             batchnorm2d_stat_mean_var(mu_a, var_a, wihi, fi, batch_size,
-                                      start_chunk, end_chunk, mu_s, var_s);
+                                      start_chunk, end_chunk, mu_s);
         });
     }
 
@@ -1141,7 +1110,7 @@ layer.
 
 void batchnorm2d_sample_var_mp(const std::vector<float> &mu_a,
                                const std::vector<float> &mu_s,
-                               const std::vector<float> &var_s, int wihi,
+                               int wihi,
                                int fi, int batch_size, const int num_threads,
                                std::vector<float> &var)
 /*Compute statistical mean and variance of activation units for
@@ -1158,8 +1127,8 @@ batch-normalization layer.
         int start_chunk = i * n_per_thread + std::min(i, extra);
         int end_chunk = start_chunk + n_per_thread + (i < extra ? 1 : 0);
 
-        threads.emplace_back([=, &mu_a, &mu_s, &var_s, &var] {
-            batchnorm2d_sample_var(mu_a, mu_s, var_s, wihi, fi, batch_size,
+        threads.emplace_back([=, &mu_a, &mu_s, &var] {
+            batchnorm2d_sample_var(mu_a, mu_s, wihi, fi, batch_size,
                                    start_chunk, end_chunk, var);
         });
     }
@@ -1552,10 +1521,9 @@ void LayerNorm::forward(BaseHiddenStates &input_states,
 
     if (this->num_threads <= 1) {
         layernorm_stat_mean_var(input_states.mu_a, input_states.var_a,
-                                this->input_size, 0, batch_size, this->mu_ra,
-                                temp_states.tmp_2);
+                                this->input_size, 0, batch_size, this->mu_ra);
 
-        layernorm_sample_var(input_states.mu_a, this->mu_ra, temp_states.tmp_2,
+        layernorm_sample_var(input_states.mu_a, this->mu_ra,
                              this->input_size, 0, batch_size, this->var_ra);
 
         if (this->normalized_shape.size() == 1) {
@@ -1578,7 +1546,7 @@ void LayerNorm::forward(BaseHiddenStates &input_states,
             this->num_threads, this->mu_ra, temp_states.tmp_2);
 
         layernorm_sample_var_mp(input_states.mu_a, this->mu_ra,
-                                temp_states.tmp_2, this->input_size, batch_size,
+                                this->input_size, batch_size,
                                 this->num_threads, this->var_ra);
 
         if (this->normalized_shape.size() == 1) {
@@ -1960,11 +1928,10 @@ void BatchNorm2d::forward(BaseHiddenStates &input_states,
             if (this->training) {
                 batchnorm_stat_mean_var(input_states.mu_a, input_states.var_a,
                                         this->input_size, batch_size, 0,
-                                        this->input_size, this->mu_norm_batch,
-                                        temp_states.tmp_2);
+                                        this->input_size, this->mu_norm_batch);
 
                 batchnorm_sample_var(input_states.mu_a, this->mu_norm_batch,
-                                     temp_states.tmp_2, this->input_size,
+                                     this->input_size,
                                      batch_size, 0, this->input_size,
                                      this->var_norm_batch);
 
@@ -1984,10 +1951,10 @@ void BatchNorm2d::forward(BaseHiddenStates &input_states,
                 batchnorm2d_stat_mean_var(
                     input_states.mu_a, input_states.var_a, wihi,
                     this->in_channels, batch_size, 0, this->in_channels,
-                    this->mu_norm_batch, temp_states.tmp_2);
+                    this->mu_norm_batch);
 
                 batchnorm2d_sample_var(input_states.mu_a, this->mu_norm_batch,
-                                       temp_states.tmp_2, wihi,
+                                       wihi,
                                        this->in_channels, batch_size, 0,
                                        this->in_channels, this->var_norm_batch);
 
@@ -2008,11 +1975,10 @@ void BatchNorm2d::forward(BaseHiddenStates &input_states,
             if (this->training) {
                 batchnorm_stat_mean_var_mp(
                     input_states.mu_a, input_states.var_a, this->input_size,
-                    batch_size, this->num_threads, this->mu_norm_batch,
-                    temp_states.tmp_2);
+                    batch_size, this->num_threads, this->mu_norm_batch);
 
                 batchnorm_sample_var_mp(input_states.mu_a, this->mu_norm_batch,
-                                        temp_states.tmp_2, this->input_size,
+                                        this->input_size,
                                         batch_size, this->num_threads,
                                         this->var_norm_batch);
 
@@ -2034,10 +2000,10 @@ void BatchNorm2d::forward(BaseHiddenStates &input_states,
                 batchnorm2d_stat_mean_var_mp(
                     input_states.mu_a, input_states.var_a, wihi,
                     this->in_channels, batch_size, this->num_threads,
-                    this->mu_norm_batch, temp_states.tmp_2);
+                    this->mu_norm_batch);
 
                 batchnorm2d_sample_var_mp(
-                    input_states.mu_a, this->mu_norm_batch, temp_states.tmp_2,
+                    input_states.mu_a, this->mu_norm_batch,
                     wihi, this->in_channels, batch_size, this->num_threads,
                     this->var_norm_batch);
 

--- a/src/norm_layer.cpp
+++ b/src/norm_layer.cpp
@@ -38,8 +38,7 @@ void layernorm_stat_mean_var(const std::vector<float> &mu_a,
 }
 
 void layernorm_sample_var(const std::vector<float> &mu_a,
-                          const std::vector<float> &mu_s,
-                          int ni,
+                          const std::vector<float> &mu_s, int ni,
                           int start_chunk, int end_chunk,
                           std::vector<float> &var_sample)
 /*
@@ -90,11 +89,11 @@ void layernorm_fwd_mean_var(
             float mu_term = adjusted_mu_a * mu_w[col];
 
             mu_z[index] = inv_sqrt_var_ra * mu_term + mu_b[col];
-            var_z[index] = inv_sqrt_var_ra * inv_sqrt_var_ra *
-                        (var_a[index] * (mu_w[col] * mu_w[col] + var_w[col])
-                        + var_w[col] * adjusted_mu_a * adjusted_mu_a
-                        )
-                        + var_b[col];
+            var_z[index] =
+                inv_sqrt_var_ra * inv_sqrt_var_ra *
+                    (var_a[index] * (mu_w[col] * mu_w[col] + var_w[col]) +
+                     var_w[col] * adjusted_mu_a * adjusted_mu_a) +
+                var_b[col];
         }
     }
 }
@@ -118,13 +117,13 @@ void layernorm2d_fwd_mean_var(
             float mu_w_term = mu_w[idx_div];
             float mu_a_tilde = mu_a[idx] - mu_ra_term;
 
-            mu_z[idx] = inv_sqrt_var_ra * mu_a_tilde * mu_w_term +
-                        mu_b[idx_div];
-            var_z[idx] = inv_sqrt_var_ra * inv_sqrt_var_ra *
-                        (var_a[idx] * (mu_w_term * mu_w_term + var_w[idx_div])
-                        + var_w[idx_div] * mu_a_tilde * mu_a_tilde
-                        )
-                        + var_b[idx_div];
+            mu_z[idx] =
+                inv_sqrt_var_ra * mu_a_tilde * mu_w_term + mu_b[idx_div];
+            var_z[idx] =
+                inv_sqrt_var_ra * inv_sqrt_var_ra *
+                    (var_a[idx] * (mu_w_term * mu_w_term + var_w[idx_div]) +
+                     var_w[idx_div] * mu_a_tilde * mu_a_tilde) +
+                var_b[idx_div];
         }
     }
 }
@@ -314,8 +313,7 @@ for each batch.
 }
 
 void batchnorm_sample_var(const std::vector<float> &mu_a,
-                          const std::vector<float> &mu_s,
-                          int ni,
+                          const std::vector<float> &mu_s, int ni,
                           int batch_size, int start_chunk, int end_chunk,
                           std::vector<float> &var)
 /*Compute statistical mean and variance of activation units for full-connected
@@ -348,13 +346,12 @@ void batchnorm_fwd_mean_var(
             float inv_sqrt_var_ra = 1.0f / std::sqrt(var_ra[col] + epsilon);
             float mu_a_tilde = mu_a[idx] - mu_ra[col];
 
-            mu_z[idx] = inv_sqrt_var_ra * mu_a_tilde * mu_w[col] +
-                        mu_b[col];
-            var_z[idx] = inv_sqrt_var_ra * inv_sqrt_var_ra *
-                        (var_a[idx] * (mu_w[col] * mu_w[col] + var_w[col])
-                        + var_w[col] * mu_a_tilde *mu_a_tilde
-                        )
-                        + var_b[col];
+            mu_z[idx] = inv_sqrt_var_ra * mu_a_tilde * mu_w[col] + mu_b[col];
+            var_z[idx] =
+                inv_sqrt_var_ra * inv_sqrt_var_ra *
+                    (var_a[idx] * (mu_w[col] * mu_w[col] + var_w[col]) +
+                     var_w[col] * mu_a_tilde * mu_a_tilde) +
+                var_b[col];
         }
     }
 }
@@ -380,8 +377,7 @@ layer.
 }
 
 void batchnorm2d_sample_var(const std::vector<float> &mu_a,
-                            const std::vector<float> &mu_s,
-                            int wihi, int fi,
+                            const std::vector<float> &mu_s, int wihi, int fi,
                             int batch_size, int start_chunk, int end_chunk,
                             std::vector<float> &var)
 /*Compute statistical mean and variance of activation units for
@@ -423,14 +419,14 @@ layer is a convolutional layer.
             int idx = col + row * k;
             float mu_a_tilde = mu_a[idx] - mu_ra_term;
 
-            mu_z[idx] = inv_sqrt_var_ra * mu_a_tilde * mu_w_term +
-                        mu_b[row % fi];
+            mu_z[idx] =
+                inv_sqrt_var_ra * mu_a_tilde * mu_w_term + mu_b[row % fi];
 
-            var_z[idx] = inv_sqrt_var_ra * inv_sqrt_var_ra *
-                (var_a[idx] * (mu_w_term * mu_w_term + var_w[row % fi])
-                + var_w[row % fi] * mu_a_tilde * mu_a_tilde
-                )
-                + var_b[row % fi];
+            var_z[idx] =
+                inv_sqrt_var_ra * inv_sqrt_var_ra *
+                    (var_a[idx] * (mu_w_term * mu_w_term + var_w[row % fi]) +
+                     var_w[row % fi] * mu_a_tilde * mu_a_tilde) +
+                var_b[row % fi];
         }
     }
 }
@@ -618,8 +614,7 @@ void layernorm_stat_mean_var_mp(const std::vector<float> &mu_a,
 }
 
 void layernorm_sample_var_mp(const std::vector<float> &mu_a,
-                             const std::vector<float> &mu_s,
-                             int ni,
+                             const std::vector<float> &mu_s, int ni,
                              int batch_size, const int num_threads,
                              std::vector<float> &var_sample)
 /*
@@ -999,8 +994,7 @@ for each batch.
 }
 
 void batchnorm_sample_var_mp(const std::vector<float> &mu_a,
-                             const std::vector<float> &mu_s,
-                             int ni,
+                             const std::vector<float> &mu_s, int ni,
                              int batch_size, const int num_threads,
                              std::vector<float> &var)
 /*
@@ -1096,9 +1090,8 @@ layer.
 }
 
 void batchnorm2d_sample_var_mp(const std::vector<float> &mu_a,
-                               const std::vector<float> &mu_s,
-                               int wihi,
-                               int fi, int batch_size, const int num_threads,
+                               const std::vector<float> &mu_s, int wihi, int fi,
+                               int batch_size, const int num_threads,
                                std::vector<float> &var)
 /*Compute statistical mean and variance of activation units for
 batch-normalization layer.
@@ -1510,8 +1503,8 @@ void LayerNorm::forward(BaseHiddenStates &input_states,
         layernorm_stat_mean_var(input_states.mu_a, input_states.var_a,
                                 this->input_size, 0, batch_size, this->mu_ra);
 
-        layernorm_sample_var(input_states.mu_a, this->mu_ra,
-                             this->input_size, 0, batch_size, this->var_ra);
+        layernorm_sample_var(input_states.mu_a, this->mu_ra, this->input_size,
+                             0, batch_size, this->var_ra);
 
         if (this->normalized_shape.size() == 1) {
             layernorm_fwd_mean_var(
@@ -1533,8 +1526,8 @@ void LayerNorm::forward(BaseHiddenStates &input_states,
             this->num_threads, this->mu_ra, temp_states.tmp_2);
 
         layernorm_sample_var_mp(input_states.mu_a, this->mu_ra,
-                                this->input_size, batch_size,
-                                this->num_threads, this->var_ra);
+                                this->input_size, batch_size, this->num_threads,
+                                this->var_ra);
 
         if (this->normalized_shape.size() == 1) {
             layernorm_fwd_mean_var_mp(
@@ -1918,9 +1911,8 @@ void BatchNorm2d::forward(BaseHiddenStates &input_states,
                                         this->input_size, this->mu_norm_batch);
 
                 batchnorm_sample_var(input_states.mu_a, this->mu_norm_batch,
-                                     this->input_size,
-                                     batch_size, 0, this->input_size,
-                                     this->var_norm_batch);
+                                     this->input_size, batch_size, 0,
+                                     this->input_size, this->var_norm_batch);
 
                 running_mean_var(this->mu_norm_batch, this->var_norm_batch,
                                  _momentum, 0, this->input_size, this->mu_ra,
@@ -1935,14 +1927,13 @@ void BatchNorm2d::forward(BaseHiddenStates &input_states,
         } else {
             int wihi = this->in_height * this->in_width;
             if (this->training) {
-                batchnorm2d_stat_mean_var(
-                    input_states.mu_a, input_states.var_a, wihi,
-                    this->in_channels, batch_size, 0, this->in_channels,
-                    this->mu_norm_batch);
+                batchnorm2d_stat_mean_var(input_states.mu_a, input_states.var_a,
+                                          wihi, this->in_channels, batch_size,
+                                          0, this->in_channels,
+                                          this->mu_norm_batch);
 
                 batchnorm2d_sample_var(input_states.mu_a, this->mu_norm_batch,
-                                       wihi,
-                                       this->in_channels, batch_size, 0,
+                                       wihi, this->in_channels, batch_size, 0,
                                        this->in_channels, this->var_norm_batch);
 
                 running_mean_var(this->mu_norm_batch, this->var_norm_batch,
@@ -1964,10 +1955,9 @@ void BatchNorm2d::forward(BaseHiddenStates &input_states,
                     input_states.mu_a, input_states.var_a, this->input_size,
                     batch_size, this->num_threads, this->mu_norm_batch);
 
-                batchnorm_sample_var_mp(input_states.mu_a, this->mu_norm_batch,
-                                        this->input_size,
-                                        batch_size, this->num_threads,
-                                        this->var_norm_batch);
+                batchnorm_sample_var_mp(
+                    input_states.mu_a, this->mu_norm_batch, this->input_size,
+                    batch_size, this->num_threads, this->var_norm_batch);
 
                 running_mean_var_mp(this->mu_norm_batch, this->var_norm_batch,
                                     momentum, this->input_size,
@@ -1990,8 +1980,8 @@ void BatchNorm2d::forward(BaseHiddenStates &input_states,
                     this->mu_norm_batch);
 
                 batchnorm2d_sample_var_mp(
-                    input_states.mu_a, this->mu_norm_batch,
-                    wihi, this->in_channels, batch_size, this->num_threads,
+                    input_states.mu_a, this->mu_norm_batch, wihi,
+                    this->in_channels, batch_size, this->num_threads,
                     this->var_norm_batch);
 
                 running_mean_var_mp(this->mu_norm_batch, this->var_norm_batch,

--- a/src/norm_layer_cuda.cu
+++ b/src/norm_layer_cuda.cu
@@ -1126,8 +1126,10 @@ void LayerNormCuda::forward(BaseHiddenStates &input_states,
     TempStateCuda *cu_temp_states = dynamic_cast<TempStateCuda *>(&temp_states);
 
     int batch_size = input_states.block_size;
+
     if (this->_batch_size < batch_size) {
         this->_batch_size = batch_size;
+        //this->set_cap_factor_udapte(batch_size);
         this->deallocate_running_mean_var();
         this->allocate_running_mean_var();
     }
@@ -1442,12 +1444,12 @@ void BatchNorm2dCuda::init_weight_bias()
     this->num_weights = this->num_features;
     this->num_biases = this->num_features;
 
-    float scale = 1.0f / sqrtf(this->num_weights);
+    float scale = 1.0f / this->num_weights;
     this->mu_w.resize(this->num_weights, 1.0f);
     this->var_w.resize(this->num_weights, scale);
     if (this->bias) {
         this->mu_b.resize(this->num_weights, 0.0f);
-        this->var_b.resize(this->num_weights, scale / 10);
+        this->var_b.resize(this->num_weights, scale);
 
     } else {
         this->num_biases = 0;
@@ -1540,6 +1542,7 @@ void BatchNorm2dCuda::forward(BaseHiddenStates &input_states,
     TempStateCuda *cu_temp_states = dynamic_cast<TempStateCuda *>(&temp_states);
 
     int batch_size = input_states.block_size;
+    //this->set_cap_factor_udapte(batch_size);
     int num_threads = this->num_cuda_threads;
     dim3 block_dim(num_threads, num_threads);
 

--- a/src/norm_layer_cuda.cu
+++ b/src/norm_layer_cuda.cu
@@ -794,7 +794,7 @@ layer is a convolutional layer.
 
         var_z[idx] = inv_var_ra *
                 (tmp_var_a * (tmp_mu_w_2 + var_w[div_idx])
-                + var_w[div_idx] * tmp_mu_a_tilde
+                + var_w[div_idx] * tmp_mu_a_tilde * tmp_mu_a_tilde
                 )
                 + var_b[div_idx];
     }

--- a/src/norm_layer_cuda.cu
+++ b/src/norm_layer_cuda.cu
@@ -236,10 +236,10 @@ __global__ void layernorm_fwd_mean_var_cuda(
                         (var_a[idx] * (mu_w_term * mu_w_term + var_w[col])
                         + var_w[col] * (mu_a_term * mu_a_term
                                         + mu_ra_term * mu_ra_term
-                                        - 2.0f *  mu_a_term * mu_ra_term
+                                        - 2.0f * mu_a_term * mu_ra_term
                                        )
                         )
-                          + var_b[col];
+                        + var_b[col];
     }
 }
 
@@ -274,7 +274,7 @@ __global__ void layernorm2d_fwd_mean_var_cuda(
                 (var_a[idx] * (mu_w_term * mu_w_term + var_w[div_idx])
                 + var_w[div_idx] * (mu_a_term * mu_a_term
                                 + mu_ra_term * mu_ra_term
-                                - 2.0f *  mu_a_term * mu_ra_term
+                                - 2.0f * mu_a_term * mu_ra_term
                                 )
                 )
                 + var_b[div_idx];

--- a/src/norm_layer_cuda.cu
+++ b/src/norm_layer_cuda.cu
@@ -153,8 +153,8 @@ __global__ void sum_reduction(float const *mu_in, size_t len_x, size_t len_y,
 
 __global__ void layernorm_stat_mean_var_cuda(float const *mu_a,
                                              float const *var_a, int ni,
-                                             int batch_size, float *mu_s,
-                                             float *var_s)
+                                             int batch_size, float *mu_s
+                                             )
 /*
  */
 {
@@ -169,12 +169,11 @@ __global__ void layernorm_stat_mean_var_cuda(float const *mu_a,
             sum_var += var_a[col * ni + i];
         }
         mu_s[col] = sum_mu / ni;
-        var_s[col] = sum_var;
     }
 }
 
 __global__ void layernorm_sample_var_cuda(float const *mu_a, float const *mu_s,
-                                          float const *var_s, int ni,
+                                          int ni,
                                           int batch_size, float *var_sample)
 /*
  */
@@ -188,9 +187,7 @@ __global__ void layernorm_sample_var_cuda(float const *mu_a, float const *mu_s,
             sum += (mu_a[col * ni + i] - mu_s[col]) *
                    (mu_a[col * ni + i] - mu_s[col]);
         }
-        //var_sample[col] = (sum + var_s[col]) / (ni - 1);
         var_sample[col] = sum / (ni - 1);
-
     }
 }
 
@@ -227,11 +224,6 @@ __global__ void layernorm_fwd_mean_var_cuda(
 
         mu_z[idx] =
             inv_sqrt_var_ra * (mu_a_term - mu_ra_term) * mu_w_term + mu_b[col];
-        /*var_z[idx] = inv_sqrt_var_ra * inv_sqrt_var_ra *
-                         (var_a[idx] * mu_w_term * mu_w_term +
-                          var_w[col] * (mu_a_term * mu_a_term -
-                                        mu_ra_term * mu_ra_term + var_a[idx])) +
-                     var_b[col];*/
         var_z[idx] = inv_sqrt_var_ra * inv_sqrt_var_ra *
                         (var_a[idx] * (mu_w_term * mu_w_term + var_w[col])
                         + var_w[col] * (mu_a_term * mu_a_term
@@ -264,12 +256,6 @@ __global__ void layernorm2d_fwd_mean_var_cuda(
 
         mu_z[idx] = inv_sqrt_var_ra * (mu_a_term - mu_ra_term) * mu_w_term +
                     mu_b[div_idx];
-        /*var_z[idx] =
-            inv_sqrt_var_ra * inv_sqrt_var_ra *
-                (var_a[idx] * mu_w_term * mu_w_term +
-                 var_w[div_idx] * (mu_a_term * mu_a_term -
-                                   mu_ra_term * mu_a_term + var_a[idx])) +
-            var_b[div_idx];*/
         var_z[idx] = inv_sqrt_var_ra * inv_sqrt_var_ra *
                 (var_a[idx] * (mu_w_term * mu_w_term + var_w[div_idx])
                 + var_w[div_idx] * (mu_a_term * mu_a_term
@@ -430,8 +416,7 @@ __global__ void delta_param_sum(float const *delta_mu_e,
 
 __global__ void batchnorm_stat_mean_var_cuda(float const *mu_a,
                                              float const *var_a, int ni,
-                                             int batch_size, float *mu_s,
-                                             float *var_s)
+                                             int batch_size, float *mu_s)
 /*Compute sample mean and variance of activation units of full-connected layer
 for each batch.
 */
@@ -446,13 +431,11 @@ for each batch.
             sum_var += var_a[col + i * ni];
         }
         mu_s[col] = sum_mu / batch_size;
-        var_s[col] = sum_var;
     }
 }
 
 __global__ void batchnorm_sample_var_cuda(float const *mu_a, float const *mu_s,
-                                          float const *var_s, int ni,
-                                          int batch_size, float *var)
+                                          int ni, int batch_size, float *var)
 /*Compute statistical mean and variance of activation units for full-connected
 layer for each batch.
 */
@@ -464,7 +447,6 @@ layer for each batch.
             sum += (mu_a[col + i * ni] - mu_s[col]) *
                    (mu_a[col + i * ni] - mu_s[col]);
         }
-        //var[col] = (sum + var_s[col]) / (batch_size - 1);
         var[col] = sum / (batch_size - 1);
     }
 }
@@ -486,11 +468,6 @@ __global__ void batchnorm_fwd_mean_var_cuda(
         mu_z[idx] =
             inv_sqrt_var_ra * (mu_a[idx] - mu_ra[col]) * mu_w[col] + mu_b[col];
 
-        /*var_z[idx] = inv_sqrt_var_ra * inv_sqrt_var_ra *
-                         (var_a[idx] * mu_w[col] * mu_w[col] +
-                          var_w[col] * (mu_a[idx] * mu_a[idx] -
-                                        mu_ra[col] * mu_ra[col] + var_a[idx])) +
-                     var_b[col];*/
         var_z[idx] = inv_sqrt_var_ra * inv_sqrt_var_ra *
                 (var_a[idx] * (mu_w[col] * mu_w[col] + var_w[col])
                 + var_w[col] * (mu_a[idx] * mu_a[idx]
@@ -726,7 +703,7 @@ void batchnorm2d_bwd_dual_sum_reduction(int batch_size, int wihi, int fi,
 __global__ void batchnorm2d_stat_mean_var_cuda(float const *mu_a,
                                                float const *var_a, int wihi,
                                                int fi, int batch_size,
-                                               float *mu_s, float *var_s)
+                                               float *mu_s)
 /*Compute sample mean and variance of activation units for batch-normalization
 layer.
 */
@@ -741,13 +718,12 @@ layer.
             sum_var += var_a[(i / wihi) * wihi * fi + i % wihi + col * wihi];
         }
         mu_s[col] = sum_mu / (wihi * batch_size);
-        var_s[col] = sum_var;
     }
 }
 
 __global__ void batchnorm2d_sample_var_cuda(float const *mu_a,
                                             float const *mu_s,
-                                            float const *var_s, int wihi,
+                                            int wihi,
                                             int fi, int batch_size, float *var)
 /*Compute statistical mean and variance of activation units for
 batch-normalization layer.
@@ -762,7 +738,6 @@ batch-normalization layer.
                    (mu_a[(i / wihi) * wihi * fi + i % wihi + col * wihi] -
                     mu_s[col]);
         }
-        //var[col] = (sum + var_s[col]) / (wihi * batch_size - 1);
         var[col] = sum / (wihi * batch_size - 1);
     }
 }
@@ -818,19 +793,15 @@ layer is a convolutional layer.
         float tmp_mu_w = mu_w[div_idx];
         float tmp_mu_w_2 = tmp_mu_w * tmp_mu_w;
         float tmp_mu_ra = mu_ra[div_idx];
-        float tmp_mu_ra_2 = tmp_mu_ra * tmp_mu_a;//!!! * tmp_mu_"r"a !!!
+        float tmp_mu_ra_2 = tmp_mu_ra * tmp_mu_ra;
         mu_z[idx] =
             inv_var_ra_sqrt * (tmp_mu_a - tmp_mu_ra) * tmp_mu_w + mu_b[div_idx];
 
-        /*var_z[idx] = inv_var_ra * (tmp_var_a * tmp_mu_w_2 +
-                                   var_w[div_idx] *
-                                       (tmp_mu_a_2 - tmp_mu_ra_2 + tmp_var_a)) +
-                     var_b[div_idx];*/
         var_z[idx] = inv_var_ra *
                 (tmp_var_a * (tmp_mu_w_2 + var_w[div_idx])
                 + var_w[div_idx] * (tmp_mu_a_2
-                                + tmp_mu_ra * tmp_mu_ra
-                                - 2.0f * tmp_mu_ra_2
+                                + tmp_mu_ra_2
+                                - 2.0f * tmp_mu_a * tmp_mu_ra
                                 )
                 )
                 + var_b[div_idx];
@@ -1129,7 +1100,7 @@ void LayerNormCuda::forward(BaseHiddenStates &input_states,
 
     if (this->_batch_size < batch_size) {
         this->_batch_size = batch_size;
-        //this->set_cap_factor_udapte(batch_size);
+        this->set_cap_factor_udapte(batch_size);
         this->deallocate_running_mean_var();
         this->allocate_running_mean_var();
     }
@@ -1151,10 +1122,10 @@ void LayerNormCuda::forward(BaseHiddenStates &input_states,
 
     layernorm_stat_mean_var_cuda<<<grid_size_ra, num_threads>>>(
         cu_input_states->d_mu_a, cu_input_states->d_var_a, this->input_size,
-        batch_size, this->d_mu_ra, cu_temp_states->d_tmp_2);
+        batch_size, this->d_mu_ra);
 
     layernorm_sample_var_cuda<<<grid_size_ra, num_threads>>>(
-        cu_input_states->d_mu_a, this->d_mu_ra, cu_temp_states->d_tmp_2,
+        cu_input_states->d_mu_a, this->d_mu_ra,
         this->input_size, batch_size, this->d_var_ra);
 
     if (this->normalized_shape.size() == 1) {
@@ -1542,7 +1513,7 @@ void BatchNorm2dCuda::forward(BaseHiddenStates &input_states,
     TempStateCuda *cu_temp_states = dynamic_cast<TempStateCuda *>(&temp_states);
 
     int batch_size = input_states.block_size;
-    //this->set_cap_factor_udapte(batch_size);
+    this->set_cap_factor_udapte(batch_size);
     int num_threads = this->num_cuda_threads;
     dim3 block_dim(num_threads, num_threads);
 
@@ -1576,12 +1547,11 @@ void BatchNorm2dCuda::forward(BaseHiddenStates &input_states,
         if (this->training) {
             batchnorm_stat_mean_var_cuda<<<grid_size_ra, num_threads>>>(
                 cu_input_states->d_mu_a, cu_input_states->d_var_a,
-                this->input_size, batch_size, this->d_mu_norm_batch,
-                cu_temp_states->d_tmp_2);
+                this->input_size, batch_size, this->d_mu_norm_batch);
 
             batchnorm_sample_var_cuda<<<grid_size_ra, num_threads>>>(
                 cu_input_states->d_mu_a, this->d_mu_norm_batch,
-                cu_temp_states->d_tmp_2, this->input_size, batch_size,
+                this->input_size, batch_size,
                 this->d_var_norm_batch);
 
             running_mean_var_cuda<<<grid_size_ra, num_threads>>>(

--- a/src/norm_layer_cuda.cu
+++ b/src/norm_layer_cuda.cu
@@ -188,7 +188,9 @@ __global__ void layernorm_sample_var_cuda(float const *mu_a, float const *mu_s,
             sum += (mu_a[col * ni + i] - mu_s[col]) *
                    (mu_a[col * ni + i] - mu_s[col]);
         }
-        var_sample[col] = (sum + var_s[col]) / (ni - 1);
+        //var_sample[col] = (sum + var_s[col]) / (ni - 1);
+        var_sample[col] = sum / (ni - 1);
+
     }
 }
 
@@ -446,7 +448,8 @@ layer for each batch.
             sum += (mu_a[col + i * ni] - mu_s[col]) *
                    (mu_a[col + i * ni] - mu_s[col]);
         }
-        var[col] = (sum + var_s[col]) / (batch_size - 1);
+        //var[col] = (sum + var_s[col]) / (batch_size - 1);
+        var[col] = sum / (batch_size - 1);
     }
 }
 
@@ -734,7 +737,8 @@ batch-normalization layer.
                    (mu_a[(i / wihi) * wihi * fi + i % wihi + col * wihi] -
                     mu_s[col]);
         }
-        var[col] = (sum + var_s[col]) / (wihi * batch_size - 1);
+        //var[col] = (sum + var_s[col]) / (wihi * batch_size - 1);
+        var[col] = sum / (wihi * batch_size - 1);
     }
 }
 

--- a/src/norm_layer_cuda.cu
+++ b/src/norm_layer_cuda.cu
@@ -227,11 +227,19 @@ __global__ void layernorm_fwd_mean_var_cuda(
 
         mu_z[idx] =
             inv_sqrt_var_ra * (mu_a_term - mu_ra_term) * mu_w_term + mu_b[col];
-        var_z[idx] = inv_sqrt_var_ra * inv_sqrt_var_ra *
+        /*var_z[idx] = inv_sqrt_var_ra * inv_sqrt_var_ra *
                          (var_a[idx] * mu_w_term * mu_w_term +
                           var_w[col] * (mu_a_term * mu_a_term -
                                         mu_ra_term * mu_ra_term + var_a[idx])) +
-                     var_b[col];
+                     var_b[col];*/
+        var_z[idx] = inv_sqrt_var_ra * inv_sqrt_var_ra *
+                        (var_a[idx] * (mu_w_term * mu_w_term + var_w[col])
+                        + var_w[col] * (mu_a_term * mu_a_term
+                                        + mu_ra_term * mu_ra_term
+                                        - 2.0f *  mu_a_term * mu_ra_term
+                                       )
+                        )
+                          + var_b[col];
     }
 }
 
@@ -256,12 +264,20 @@ __global__ void layernorm2d_fwd_mean_var_cuda(
 
         mu_z[idx] = inv_sqrt_var_ra * (mu_a_term - mu_ra_term) * mu_w_term +
                     mu_b[div_idx];
-        var_z[idx] =
+        /*var_z[idx] =
             inv_sqrt_var_ra * inv_sqrt_var_ra *
                 (var_a[idx] * mu_w_term * mu_w_term +
                  var_w[div_idx] * (mu_a_term * mu_a_term -
                                    mu_ra_term * mu_a_term + var_a[idx])) +
-            var_b[div_idx];
+            var_b[div_idx];*/
+        var_z[idx] = inv_sqrt_var_ra * inv_sqrt_var_ra *
+                (var_a[idx] * (mu_w_term * mu_w_term + var_w[div_idx])
+                + var_w[div_idx] * (mu_a_term * mu_a_term
+                                + mu_ra_term * mu_ra_term
+                                - 2.0f *  mu_a_term * mu_ra_term
+                                )
+                )
+                + var_b[col];
     }
 }
 
@@ -470,11 +486,20 @@ __global__ void batchnorm_fwd_mean_var_cuda(
         mu_z[idx] =
             inv_sqrt_var_ra * (mu_a[idx] - mu_ra[col]) * mu_w[col] + mu_b[col];
 
-        var_z[idx] = inv_sqrt_var_ra * inv_sqrt_var_ra *
+        /*var_z[idx] = inv_sqrt_var_ra * inv_sqrt_var_ra *
                          (var_a[idx] * mu_w[col] * mu_w[col] +
                           var_w[col] * (mu_a[idx] * mu_a[idx] -
                                         mu_ra[col] * mu_ra[col] + var_a[idx])) +
-                     var_b[col];
+                     var_b[col];*/
+        var_z[idx] = inv_sqrt_var_ra * inv_sqrt_var_ra *
+                (var_a[idx] * (mu_w[col] * mu_w[col] + var_w[col])
+                + var_w[col] * (mu_a[idx] * mu_a[idx]
+                                + mu_ra[col] * mu_ra[col]
+                                - 2.0f *  mu_a[idx] * mu_ra[col]
+                                )
+                )
+                + var_b[col];
+
     }
 }
 
@@ -793,14 +818,22 @@ layer is a convolutional layer.
         float tmp_mu_w = mu_w[div_idx];
         float tmp_mu_w_2 = tmp_mu_w * tmp_mu_w;
         float tmp_mu_ra = mu_ra[div_idx];
-        float tmp_mu_ra_2 = tmp_mu_ra * tmp_mu_a;
+        float tmp_mu_ra_2 = tmp_mu_ra * tmp_mu_a;//!!! * tmp_mu_"r"a !!!
         mu_z[idx] =
             inv_var_ra_sqrt * (tmp_mu_a - tmp_mu_ra) * tmp_mu_w + mu_b[div_idx];
 
-        var_z[idx] = inv_var_ra * (tmp_var_a * tmp_mu_w_2 +
+        /*var_z[idx] = inv_var_ra * (tmp_var_a * tmp_mu_w_2 +
                                    var_w[div_idx] *
                                        (tmp_mu_a_2 - tmp_mu_ra_2 + tmp_var_a)) +
-                     var_b[div_idx];
+                     var_b[div_idx];*/
+        var_z[idx] = inv_var_ra *
+                (tmp_var_a * (tmp_mu_w_2 + var_w[div_idx])
+                + var_w[div_idx] * (tmp_mu_a_2
+                                + tmp_mu_ra * tmp_mu_ra
+                                - 2.0f *  tmp_mu_ra_2
+                                )
+                )
+                + var_b[div_idx];
     }
 }
 

--- a/src/norm_layer_cuda.cu
+++ b/src/norm_layer_cuda.cu
@@ -459,8 +459,8 @@ __global__ void batchnorm_fwd_mean_var_cuda(
     int col = blockIdx.x * blockDim.x + threadIdx.x;
     if (col < ni && row < batch_size) {
         float inv_sqrt_var_ra = 1.0f / sqrtf(var_ra[col] + epsilon);
-        float mu_a_tilde = mu_a[idx] - mu_ra[col];
         int idx = col + row * ni;
+        float mu_a_tilde = mu_a[idx] - mu_ra[col];
 
         mu_z[idx] =
             inv_sqrt_var_ra * mu_a_tilde * mu_w[col] + mu_b[col];

--- a/src/norm_layer_cuda.cu
+++ b/src/norm_layer_cuda.cu
@@ -783,11 +783,9 @@ layer is a convolutional layer.
 
         float tmp_mu_a = mu_a[idx];
         float tmp_var_a = var_a[idx];
-        float tmp_mu_a_2 = tmp_mu_a * tmp_mu_a;
         float tmp_mu_w = mu_w[div_idx];
         float tmp_mu_w_2 = tmp_mu_w * tmp_mu_w;
         float tmp_mu_ra = mu_ra[div_idx];
-        float tmp_mu_ra_2 = tmp_mu_ra * tmp_mu_ra;
         float tmp_mu_a_tilde = tmp_mu_a - tmp_mu_ra;
         mu_z[idx] =
             inv_var_ra_sqrt * tmp_mu_a_tilde * tmp_mu_w + mu_b[div_idx];
@@ -1086,7 +1084,7 @@ void LayerNormCuda::forward(BaseHiddenStates &input_states,
         dynamic_cast<HiddenStateCuda *>(&input_states);
     HiddenStateCuda *cu_output_states =
         dynamic_cast<HiddenStateCuda *>(&output_states);
-    TempStateCuda *cu_temp_states = dynamic_cast<TempStateCuda *>(&temp_states);
+    //TempStateCuda *cu_temp_states = dynamic_cast<TempStateCuda *>(&temp_states);
 
     int batch_size = input_states.block_size;
 

--- a/src/norm_layer_cuda.cu
+++ b/src/norm_layer_cuda.cu
@@ -277,7 +277,7 @@ __global__ void layernorm2d_fwd_mean_var_cuda(
                                 - 2.0f *  mu_a_term * mu_ra_term
                                 )
                 )
-                + var_b[col];
+                + var_b[div_idx];
     }
 }
 
@@ -495,7 +495,7 @@ __global__ void batchnorm_fwd_mean_var_cuda(
                 (var_a[idx] * (mu_w[col] * mu_w[col] + var_w[col])
                 + var_w[col] * (mu_a[idx] * mu_a[idx]
                                 + mu_ra[col] * mu_ra[col]
-                                - 2.0f *  mu_a[idx] * mu_ra[col]
+                                - 2.0f * mu_a[idx] * mu_ra[col]
                                 )
                 )
                 + var_b[col];
@@ -830,7 +830,7 @@ layer is a convolutional layer.
                 (tmp_var_a * (tmp_mu_w_2 + var_w[div_idx])
                 + var_w[div_idx] * (tmp_mu_a_2
                                 + tmp_mu_ra * tmp_mu_ra
-                                - 2.0f *  tmp_mu_ra_2
+                                - 2.0f * tmp_mu_ra_2
                                 )
                 )
                 + var_b[div_idx];

--- a/test/fnn/test_fnn_mnist_cpu.cpp
+++ b/test/fnn/test_fnn_mnist_cpu.cpp
@@ -84,10 +84,10 @@ void fnn_mnist() {
     //                  AvgPool2d(3, 2), Linear(32 * 4 * 4, 100), ReLU(),
     //                  Linear(100, 11));
 
-    Sequential model(Conv2d(1, 32, 4, false, 1, 1, 1, 28, 28), BatchNorm2d(16),
+    Sequential model(Conv2d(1, 32, 4, false, 1, 1, 1, 28, 28), BatchNorm2d(32),
                      ReLU(), AvgPool2d(3, 2), Conv2d(32, 64, 5, false),
                      BatchNorm2d(64), ReLU(), AvgPool2d(3, 2),
-                     Linear(64 * 4 * 4, 100), ReLU(), Linear(256, 11));
+                     Linear(64 * 4 * 4, 128), ReLU(), Linear(128, 11));
 
     // Sequential model(Conv2d(1, 16, 4, false, 1, 1, 1, 28, 28),
     //                  LayerNorm(std::vector<int>({16, 27, 27})), ReLU(),
@@ -96,7 +96,7 @@ void fnn_mnist() {
     //                  AvgPool2d(3, 2), Linear(32 * 4 * 4, 100), ReLU(),
     //                  Linear(100, 11));
 
-    // model.set_threads(8);
+    // model.set_threads(1);
     model.to_device("cuda");
     // model.preinit_layer();
     // model.load("test_model/test_model.bin");
@@ -143,7 +143,7 @@ void fnn_mnist() {
     unsigned seed = std::chrono::system_clock::now().time_since_epoch().count();
     std::default_random_engine seed_e(seed);
     int n_epochs = 1;
-    int batch_size = 256;
+    int batch_size = 16;
     float sigma_obs = 2.0;
     int iters = train_db.num_data / batch_size;
     std::cout << "num_iter: " << iters << "\n";


### PR DESCRIPTION
# Description

This PR correct the following errors in the norm_layer*

1. Uniformize parameter initialization across c++ and cuda versions
2. Call the `set_cap_factor_update update` in the cuda version
3. Correct a typo in `batchnorm2d_fwd_mean_var_cuda()`
4. Remove the epistemic variance term from the normalization std
<img width="317" alt="Screenshot 2024-09-17 at 14 39 46" src="https://github.com/user-attachments/assets/e9a97d13-3403-4030-ab56-b41ed48c0988">

5. Correct an error in the forward's variance calculation 
<img width="413" alt="Screenshot 2024-09-17 at 14 41 30" src="https://github.com/user-attachments/assets/2fe663f8-2a2b-4ca7-bf79-241e1f274f93">

See the [working document](https://www.dropbox.com/scl/fi/vjg3b9a605lolcx3qhsy0/TAGI_BLN_Nguyen_Goulet_2024.pdf?rlkey=gk8x3mo10q7mo25i90sx4lu9e&dl=0) for theoretical details about the corrections made.

# Changes Made

1. For both the c++ and cuda versions, the weight parameters are now initialized as `float scale = 1.0f / this->num_weights;`
2. Add `this->set_cap_factor_udapte(batch_size);` in the `norm_layer_cuda.cu` for both the Batch- and Layer-Normalization. 
3. In `batchnorm2d_fwd_mean_var_cuda()`, the following typo was corrected: `tmp_mu_ra_2 = tmp_mu_ra * tmp_mu_a` -> `tmp_mu_ra_2 = tmp_mu_ra * tmp_mu_ra`
4. The epistemic variance term has been removed from the variance calculations as well as from the input and outputs
5. The formulation for the forward's variance calculations have been updated with the new one available in the [working document](https://www.dropbox.com/scl/fi/vjg3b9a605lolcx3qhsy0/TAGI_BLN_Nguyen_Goulet_2024.pdf?rlkey=gk8x3mo10q7mo25i90sx4lu9e&dl=0).

# Note for Reviewers

Although the corrections mentioned above are required from a theoretical standpoint, they are not solving the performance issues observed for the resnet18 applied on Cifar10. 
I have tested the changes proposed on CPU & CPU using the `classification.py` MNIST benchmark with the `FNN_LAYERNORM` and `FNN_BATCHNORM` architectures. One thing I noted on that benchmark is that layer-normalization is working properly for both CPU and GPU. On the other hand batch-normalization works properly on CPU but fails to learn (i.e., error = ~90%) on GPU. I suspect that this is cause by a bug in batch-normalization but I have not been able to pinpoint the source yet. 