### PR TITLE
Bugfix  - negative variance update

### DIFF
--- a/examples/cifar_resnet_bench.py
+++ b/examples/cifar_resnet_bench.py
@@ -226,7 +226,7 @@ def tagi_trainer(
 
     # Resnet18
     # net = TAGI_CNN_NET
-    net = resnet18_cifar10(gain=1)
+    net = resnet18_cifar10(gain=0.2)
     net.to_device(device)
     # net.set_threads(10)
     out_updater = OutputUpdater(net.device)
@@ -366,10 +366,10 @@ def torch_trainer(batch_size: int, num_epochs: int, device: str = "cuda"):
 
 def main(
     framework: str = "tagi",
-    batch_size: int = 48,
+    batch_size: int = 128,
     epochs: int = 50,
     device: str = "cuda",
-    sigma_v: float = 0.2,
+    sigma_v: float = 0.1,
 ):
     if framework == "torch":
         torch_trainer(batch_size=batch_size, num_epochs=epochs, device=device)

--- a/examples/cifar_resnet_bench.py
+++ b/examples/cifar_resnet_bench.py
@@ -39,18 +39,18 @@ NORMALIZATION_STD = [0.2470, 0.2435, 0.2616]
 TAGI_CNN_NET = Sequential(
     # 32x32
     Conv2d(3, 32, 5, bias=False, padding=2, in_width=32, in_height=32),
-    BatchNorm2d(32),
     MixtureReLU(),
+    BatchNorm2d(32),
     AvgPool2d(2, 2),
     # 16x16
     Conv2d(32, 32, 5, bias=False, padding=2),
-    BatchNorm2d(32),
     MixtureReLU(),
+    BatchNorm2d(32),
     AvgPool2d(2, 2),
     # 8x8
     Conv2d(32, 64, 5, bias=False, padding=2),
-    BatchNorm2d(64),
     MixtureReLU(),
+    BatchNorm2d(64),
     AvgPool2d(2, 2),
     # 4x4
     Linear(64 * 4 * 4, 256),
@@ -226,7 +226,7 @@ def tagi_trainer(
 
     # Resnet18
     # net = TAGI_CNN_NET
-    net = resnet18_cifar10(gain=0.2)
+    net = resnet18_cifar10(gain_w=0.15, gain_b=0.15)
     net.to_device(device)
     # net.set_threads(10)
     out_updater = OutputUpdater(net.device)

--- a/examples/cifar_resnet_bench.py
+++ b/examples/cifar_resnet_bench.py
@@ -226,7 +226,7 @@ def tagi_trainer(
 
     # Resnet18
     # net = TAGI_CNN_NET
-    net = resnet18_cifar10()
+    net = resnet18_cifar10(gain=0.2)
     net.to_device(device)
     # net.set_threads(10)
     out_updater = OutputUpdater(net.device)
@@ -241,7 +241,7 @@ def tagi_trainer(
         error_rates = []
         if epoch > 0:
             sigma_v = exponential_scheduler(
-                curr_v=sigma_v, min_v=0.2, decaying_factor=0.99, curr_iter=epoch
+                curr_v=sigma_v, min_v=0, decaying_factor=1, curr_iter=epoch
             )
             var_y = np.full(
                 (batch_size * metric.hrc_softmax.num_obs,),
@@ -365,7 +365,7 @@ def main(
     batch_size: int = 128,
     epochs: int = 50,
     device: str = "cuda",
-    sigma_v: float = 1,
+    sigma_v: float = 0.1,
 ):
     if framework == "torch":
         torch_trainer(batch_size=batch_size, num_epochs=epochs, device=device)

--- a/examples/cifar_resnet_bench.py
+++ b/examples/cifar_resnet_bench.py
@@ -226,7 +226,7 @@ def tagi_trainer(
 
     # Resnet18
     # net = TAGI_CNN_NET
-    net = resnet18_cifar10(gain=0.2)
+    net = resnet18_cifar10(gain=1)
     net.to_device(device)
     # net.set_threads(10)
     out_updater = OutputUpdater(net.device)
@@ -237,7 +237,7 @@ def tagi_trainer(
         (batch_size * metric.hrc_softmax.num_obs,), sigma_v**2, dtype=np.float32
     )
     pbar = tqdm(range(num_epochs), desc="Training Progress")
-    print_var = False
+    print_var = True
     for epoch in pbar:
         error_rates = []
         if epoch > 0:
@@ -366,10 +366,10 @@ def torch_trainer(batch_size: int, num_epochs: int, device: str = "cuda"):
 
 def main(
     framework: str = "tagi",
-    batch_size: int = 128,
+    batch_size: int = 48,
     epochs: int = 50,
     device: str = "cuda",
-    sigma_v: float = 0.1,
+    sigma_v: float = 0.2,
 ):
     if framework == "torch":
         torch_trainer(batch_size=batch_size, num_epochs=epochs, device=device)

--- a/examples/cifar_resnet_bench.py
+++ b/examples/cifar_resnet_bench.py
@@ -237,6 +237,7 @@ def tagi_trainer(
         (batch_size * metric.hrc_softmax.num_obs,), sigma_v**2, dtype=np.float32
     )
     pbar = tqdm(range(num_epochs), desc="Training Progress")
+    print_var = False
     for epoch in pbar:
         error_rates = []
         if epoch > 0:
@@ -252,6 +253,9 @@ def tagi_trainer(
         for x, labels in train_loader:
             # Feedforward and backward pass
             m_pred, v_pred = net(x)
+            if print_var: # Print prior predictive variance
+                print("Prior predictive -> E[v_pred] = ", np.average(v_pred), "+-", np.std(v_pred))
+                print_var = False
 
             # Update output layers based on targets
             y, y_idx, _ = utils.label_to_obs(labels=labels, num_classes=10)

--- a/examples/classification.py
+++ b/examples/classification.py
@@ -57,12 +57,12 @@ CNN = Sequential(
 
 CNN_BATCHNORM = Sequential(
     Conv2d(1, 16, 4, padding=1, in_width=28, in_height=28, bias=False),
-    BatchNorm2d(16),
     MixtureReLU(),
+    BatchNorm2d(16),
     AvgPool2d(3, 2),
     Conv2d(16, 32, 5, bias=False),
-    BatchNorm2d(32),
     MixtureReLU(),
+    BatchNorm2d(32),
     AvgPool2d(3, 2),
     Linear(32 * 4 * 4, 100),
     MixtureReLU(),
@@ -71,12 +71,12 @@ CNN_BATCHNORM = Sequential(
 
 CNN_LAYERNORM = Sequential(
     Conv2d(1, 16, 4, padding=1, in_width=28, in_height=28, bias=False),
-    LayerNorm((16, 27, 27)),
     MixtureReLU(),
+    LayerNorm((16, 27, 27)),
     AvgPool2d(3, 2),
     Conv2d(16, 32, 5, bias=False),
-    LayerNorm((32, 9, 9)),
     MixtureReLU(),
+    LayerNorm((32, 9, 9)),
     AvgPool2d(3, 2),
     Linear(32 * 4 * 4, 100),
     MixtureReLU(),
@@ -106,7 +106,7 @@ def main(num_epochs: int = 10, batch_size: int = 1, sigma_v: float = 0.1):
     metric = HRCSoftmaxMetric(num_classes=10)
 
     # Network configuration
-    net = CNN_LAYERNORM
+    net = CNN
     net.to_device("cuda")
     #net.set_threads(16)
     out_updater = OutputUpdater(net.device)

--- a/examples/classification.py
+++ b/examples/classification.py
@@ -42,29 +42,17 @@ FNN_LAYERNORM = Sequential(
     LayerNorm((100,)),
     Linear(100, 11),
 )
-gain = 1.6
+
 CNN = Sequential(
-    Conv2d(1, 16, 4, padding=1, in_width=28, in_height=28,
-    #        gain_weight = gain,
-    #        gain_bias = gain
-    ),
+    Conv2d(1, 16, 4, padding=1, in_width=28, in_height=28),
     MixtureReLU(),
     AvgPool2d(3, 2),
-    Conv2d(16, 32, 5,
-    #        gain_weight = gain,
-    #        gain_bias = gain
-    ),
+    Conv2d(16, 32, 5),
     MixtureReLU(),
     AvgPool2d(3, 2),
-    Linear(32 * 4 * 4, 100,
-    #        gain_weight = gain,
-    #        gain_bias = gain
-    ),
+    Linear(32 * 4 * 4, 100),
     MixtureReLU(),
-    Linear(100, 11,
-    #        gain_weight = gain,
-    #        gain_bias = gain
-    ),
+    Linear(100, 11),
 )
 
 CNN_BATCHNORM = Sequential(
@@ -96,7 +84,7 @@ CNN_LAYERNORM = Sequential(
 )
 
 
-def main(num_epochs: int = 10, batch_size: int = 128, sigma_v: float = 0.1):
+def main(num_epochs: int = 10, batch_size: int = 1, sigma_v: float = 0.1):
     """
     Run classification training on the MNIST dataset using a custom neural model.
     Parameters:
@@ -118,7 +106,7 @@ def main(num_epochs: int = 10, batch_size: int = 128, sigma_v: float = 0.1):
     metric = HRCSoftmaxMetric(num_classes=10)
 
     # Network configuration
-    net = CNN
+    net = CNN_LAYERNORM
     net.to_device("cuda")
     #net.set_threads(16)
     out_updater = OutputUpdater(net.device)
@@ -129,7 +117,7 @@ def main(num_epochs: int = 10, batch_size: int = 128, sigma_v: float = 0.1):
         (batch_size * metric.hrc_softmax.num_obs,), sigma_v**2, dtype=np.float32
     )
     pbar = tqdm(range(num_epochs), desc="Training Progress")
-    print_var = True
+    print_var = False
     for epoch in pbar:
         batch_iter = train_dtl.create_data_loader(batch_size=batch_size)
         for x, y, y_idx, label in batch_iter:

--- a/examples/classification.py
+++ b/examples/classification.py
@@ -45,22 +45,26 @@ FNN_LAYERNORM = Sequential(
 gain = 1.6
 CNN = Sequential(
     Conv2d(1, 16, 4, padding=1, in_width=28, in_height=28,
-            gain_weight = gain,
-            gain_bias = gain),
+    #        gain_weight = gain,
+    #        gain_bias = gain
+    ),
     MixtureReLU(),
     AvgPool2d(3, 2),
     Conv2d(16, 32, 5,
-            gain_weight = gain,
-            gain_bias = gain),
+    #        gain_weight = gain,
+    #        gain_bias = gain
+    ),
     MixtureReLU(),
     AvgPool2d(3, 2),
     Linear(32 * 4 * 4, 100,
-            gain_weight = gain,
-            gain_bias = gain),
+    #        gain_weight = gain,
+    #        gain_bias = gain
+    ),
     MixtureReLU(),
     Linear(100, 11,
-            gain_weight = gain,
-            gain_bias = gain),
+    #        gain_weight = gain,
+    #        gain_bias = gain
+    ),
 )
 
 CNN_BATCHNORM = Sequential(
@@ -114,7 +118,7 @@ def main(num_epochs: int = 10, batch_size: int = 128, sigma_v: float = 0.1):
     metric = HRCSoftmaxMetric(num_classes=10)
 
     # Network configuration
-    net = CNN_BATCHNORM
+    net = CNN
     net.to_device("cuda")
     #net.set_threads(16)
     out_updater = OutputUpdater(net.device)

--- a/examples/tagi_resnet_model.py
+++ b/examples/tagi_resnet_model.py
@@ -10,7 +10,7 @@ from pytagi.nn import (
 )
 
 
-def make_layer_block(in_c: int, out_c: int, stride: int = 1, padding_type: int = 1, gain: float = 1):
+def make_layer_block(in_c: int, out_c: int, stride: int = 1, padding_type: int = 1):
     """Create a layer block for resnet 18"""
 
     return LayerBlock(
@@ -22,8 +22,6 @@ def make_layer_block(in_c: int, out_c: int, stride: int = 1, padding_type: int =
             stride=stride,
             padding=1,
             padding_type=padding_type,
-            gain_weight = gain,
-            gain_bias = gain,
         ),
         BatchNorm2d(out_c),
         MixtureReLU(),
@@ -31,8 +29,7 @@ def make_layer_block(in_c: int, out_c: int, stride: int = 1, padding_type: int =
                out_c, 3,
                bias=False,
                padding=1,
-               gain_weight = gain,
-               gain_bias = gain),
+        ),
         BatchNorm2d(out_c),
         MixtureReLU(),
     )
@@ -46,44 +43,40 @@ def resnet18_cifar10(gain: float = 1) -> Sequential:
                bias=False,
                padding=1,
                in_width=32, in_height=32,
-               gain_weight = gain,
-               gain_bias = gain),
+        ),
         BatchNorm2d(64),
         MixtureReLU(),
     ]
 
     resnet_layers = [
         # 32x32
-        ResNetBlock(make_layer_block(64, 64, gain=gain)),
-        ResNetBlock(make_layer_block(64, 64, gain=gain)),
+        ResNetBlock(make_layer_block(64, 64)),
+        ResNetBlock(make_layer_block(64, 64)),
         # 16x16
         ResNetBlock(
-            make_layer_block(64, 128, 2, 2, gain),
-            LayerBlock(Conv2d(64, 128, 2, bias=False, stride=2,
-            gain_weight = gain,
-            gain_bias = gain), BatchNorm2d(128)),
+            make_layer_block(64, 128, 2, 2),
+            LayerBlock(Conv2d(64, 128, 2, bias=False, stride=2),
+                        BatchNorm2d(128)),
         ),
-        ResNetBlock(make_layer_block(128, 128, gain=gain)),
+        ResNetBlock(make_layer_block(128, 128)),
         # 8x8
         ResNetBlock(
-            make_layer_block(128, 256, 2, 2, gain=gain),
-            LayerBlock(Conv2d(128, 256, 2, bias=False, stride=2,
-            gain_weight = gain,
-            gain_bias = gain), BatchNorm2d(256)),
+            make_layer_block(128, 256, 2, 2),
+            LayerBlock(Conv2d(128, 256, 2, bias=False, stride=2),
+                        BatchNorm2d(256)),
         ),
-        ResNetBlock(make_layer_block(256, 256, gain=gain)),
+        ResNetBlock(make_layer_block(256, 256)),
         # 4x4
         ResNetBlock(
-            make_layer_block(256, 512, 2, 2, gain=gain),
-            LayerBlock(Conv2d(256, 512, 2, bias=False, stride=2,
-            gain_weight = gain,
-            gain_bias = gain,), BatchNorm2d(512)),
+            make_layer_block(256, 512, 2, 2),
+            LayerBlock(Conv2d(256, 512, 2, bias=False, stride=2),
+                        BatchNorm2d(512)),
         ),
-        ResNetBlock(make_layer_block(512, 512, gain=gain)),
+        ResNetBlock(make_layer_block(512, 512)),
     ]
 
     final_layers = [AvgPool2d(4),
-                    Linear(512, 11, gain_weight = gain, gain_bias = gain)
+                    Linear(512, 11)
     ]
 
     return Sequential(*initial_layers, *resnet_layers, *final_layers)

--- a/examples/tagi_resnet_model.py
+++ b/examples/tagi_resnet_model.py
@@ -54,36 +54,36 @@ def resnet18_cifar10(gain: float = 1) -> Sequential:
 
     resnet_layers = [
         # 32x32
-        ResNetBlock(make_layer_block(64, 64), gain=gain),
-        ResNetBlock(make_layer_block(64, 64), gain=gain),
+        ResNetBlock(make_layer_block(64, 64, gain=gain)),
+        ResNetBlock(make_layer_block(64, 64, gain=gain)),
         # 16x16
         ResNetBlock(
-            make_layer_block(64, 128, 2, 2),
+            make_layer_block(64, 128, 2, 2, gain),
             LayerBlock(Conv2d(64, 128, 2, bias=False, stride=2,
-                                gain_weight = gain,
-                                gain_bias = gain), BatchNorm2d(128)),
-        gain=gain),
-        ResNetBlock(make_layer_block(128, 128)),
+            gain_weight = gain,
+            gain_bias = gain), BatchNorm2d(128)),
+        ),
+        ResNetBlock(make_layer_block(128, 128, gain=gain)),
         # 8x8
         ResNetBlock(
-            make_layer_block(128, 256, 2, 2),
+            make_layer_block(128, 256, 2, 2, gain=gain),
             LayerBlock(Conv2d(128, 256, 2, bias=False, stride=2,
-                                gain_weight = gain,
-                                gain_bias = gain), BatchNorm2d(256)),
-        gain=gain),
-        ResNetBlock(make_layer_block(256, 256), gain=gain),
+            gain_weight = gain,
+            gain_bias = gain), BatchNorm2d(256)),
+        ),
+        ResNetBlock(make_layer_block(256, 256, gain=gain)),
         # 4x4
         ResNetBlock(
-            make_layer_block(256, 512, 2, 2),
+            make_layer_block(256, 512, 2, 2, gain=gain),
             LayerBlock(Conv2d(256, 512, 2, bias=False, stride=2,
-                                gain_weight = gain,
-                                gain_bias = gain), BatchNorm2d(512)),
-        gain=gain),
-        ResNetBlock(make_layer_block(512, 512), gain=gain),
+            gain_weight = gain,
+            gain_bias = gain,), BatchNorm2d(512)),
+        ),
+        ResNetBlock(make_layer_block(512, 512, gain=gain)),
     ]
 
-    final_layers = [AvgPool2d(4), Linear(512, 11,
-                                gain_weight = gain,
-                                gain_bias = gain)]
+    final_layers = [AvgPool2d(4),
+                    Linear(512, 11, gain_weight = gain, gain_bias = gain)
+    ]
 
     return Sequential(*initial_layers, *resnet_layers, *final_layers)

--- a/examples/tagi_resnet_model.py
+++ b/examples/tagi_resnet_model.py
@@ -10,7 +10,7 @@ from pytagi.nn import (
 )
 
 
-def make_layer_block(in_c: int, out_c: int, stride: int = 1, padding_type: int = 1, gain: float = 1):
+def make_layer_block(in_c: int, out_c: int, stride: int = 1, padding_type: int = 1, gain_weight: float = 1, gain_bias: float = 1):
     """Create a layer block for resnet 18"""
 
     return LayerBlock(
@@ -22,8 +22,8 @@ def make_layer_block(in_c: int, out_c: int, stride: int = 1, padding_type: int =
             stride=stride,
             padding=1,
             padding_type=padding_type,
-            gain_weight = gain,
-            gain_bias = gain,
+            gain_weight = gain_weight,
+            gain_bias = gain_bias,
         ),
         MixtureReLU(),
         BatchNorm2d(out_c),
@@ -31,14 +31,14 @@ def make_layer_block(in_c: int, out_c: int, stride: int = 1, padding_type: int =
                out_c, 3,
                bias=False,
                padding=1,
-               gain_weight = gain,
-               gain_bias = gain),
+               gain_weight = gain_weight,
+               gain_bias = gain_bias),
         MixtureReLU(),
         BatchNorm2d(out_c),
     )
 
 
-def resnet18_cifar10(gain: float = 1) -> Sequential:
+def resnet18_cifar10(gain_w: float = 1, gain_b: float = 1) -> Sequential:
     """Resnet18 architecture for cifar10"""
     # 32x32
     initial_layers = [
@@ -46,44 +46,44 @@ def resnet18_cifar10(gain: float = 1) -> Sequential:
                bias=False,
                padding=1,
                in_width=32, in_height=32,
-               gain_weight = gain,
-               gain_bias = gain),
+               gain_weight = gain_w,
+               gain_bias = gain_b),
         MixtureReLU(),
         BatchNorm2d(64),
     ]
 
     resnet_layers = [
         # 32x32
-        ResNetBlock(make_layer_block(64, 64, gain=gain)),
-        ResNetBlock(make_layer_block(64, 64, gain=gain)),
+        ResNetBlock(make_layer_block(64, 64, gain_weight=gain_w, gain_bias=gain_b)),
+        ResNetBlock(make_layer_block(64, 64, gain_weight=gain_w, gain_bias=gain_b)),
         # 16x16
         ResNetBlock(
-            make_layer_block(64, 128, 2, 2, gain),
+            make_layer_block(64, 128, 2, 2, gain_weight=gain_w, gain_bias=gain_b),
             LayerBlock(Conv2d(64, 128, 2, bias=False, stride=2,
-            gain_weight = gain,
-            gain_bias = gain), BatchNorm2d(128))
+            gain_weight = gain_w,
+            gain_bias = gain_b), BatchNorm2d(128))
         ),
-        ResNetBlock(make_layer_block(128, 128, gain=gain)),
+        ResNetBlock(make_layer_block(128, 128, gain_weight=gain_w, gain_bias=gain_b)),
         # 8x8
         ResNetBlock(
-            make_layer_block(128, 256, 2, 2, gain=gain),
+            make_layer_block(128, 256, 2, 2, gain_weight=gain_w, gain_bias=gain_b),
             LayerBlock(Conv2d(128, 256, 2, bias=False, stride=2,
-            gain_weight = gain,
-            gain_bias = gain), BatchNorm2d(256))
+            gain_weight = gain_w,
+            gain_bias = gain_b), BatchNorm2d(256))
         ),
-        ResNetBlock(make_layer_block(256, 256, gain=gain)),
+        ResNetBlock(make_layer_block(256, 256, gain_weight=gain_w, gain_bias=gain_b)),
         # 4x4
         ResNetBlock(
-            make_layer_block(256, 512, 2, 2, gain=gain),
+            make_layer_block(256, 512, 2, 2, gain_weight=gain_w, gain_bias=gain_b),
             LayerBlock(Conv2d(256, 512, 2, bias=False, stride=2,
-            gain_weight = gain,
-            gain_bias = gain,), BatchNorm2d(512))
+            gain_weight = gain_w,
+            gain_bias = gain_b), BatchNorm2d(512))
         ),
-        ResNetBlock(make_layer_block(512, 512, gain=gain)),
+        ResNetBlock(make_layer_block(512, 512, gain_weight=gain_w, gain_bias=gain_b))
     ]
 
     final_layers = [AvgPool2d(4),
-                    Linear(512, 11, gain_weight = gain, gain_bias = gain)
+                    Linear(512, 11, gain_weight = gain_b, gain_bias = gain_b)
     ]
 
     return Sequential(*initial_layers, *resnet_layers, *final_layers)

--- a/examples/tagi_resnet_model.py
+++ b/examples/tagi_resnet_model.py
@@ -4,13 +4,13 @@ from pytagi.nn import (
     Conv2d,
     LayerBlock,
     Linear,
-    ReLU,
+    MixtureReLU,
     ResNetBlock,
     Sequential,
 )
 
 
-def make_layer_block(in_c: int, out_c: int, stride: int = 1, padding_type: int = 1):
+def make_layer_block(in_c: int, out_c: int, stride: int = 1, padding_type: int = 1, gain: float = 1):
     """Create a layer block for resnet 18"""
 
     return LayerBlock(
@@ -22,55 +22,68 @@ def make_layer_block(in_c: int, out_c: int, stride: int = 1, padding_type: int =
             stride=stride,
             padding=1,
             padding_type=padding_type,
+            gain_weight = gain,
+            gain_bias = gain,
         ),
         BatchNorm2d(out_c),
-        ReLU(),
-        Conv2d(out_c, out_c, 3, bias=False, padding=1),
+        MixtureReLU(),
+        Conv2d(out_c,
+               out_c, 3,
+               bias=False,
+               padding=1,
+               gain_weight = gain,
+               gain_bias = gain),
         BatchNorm2d(out_c),
+        MixtureReLU(),
     )
 
 
-def resnet18_cifar10() -> Sequential:
+def resnet18_cifar10(gain: float = 1) -> Sequential:
     """Resnet18 architecture for cifar10"""
     # 32x32
     initial_layers = [
-        Conv2d(3, 64, 3, bias=False, padding=1, in_width=32, in_height=32),
+        Conv2d(3, 64, 3,
+               bias=False,
+               padding=1,
+               in_width=32, in_height=32,
+               gain_weight = gain,
+               gain_bias = gain),
         BatchNorm2d(64),
-        ReLU(),
+        MixtureReLU(),
     ]
 
     resnet_layers = [
         # 32x32
-        ResNetBlock(make_layer_block(64, 64)),
-        ReLU(),
-        ResNetBlock(make_layer_block(64, 64)),
-        ReLU(),
+        ResNetBlock(make_layer_block(64, 64), gain=gain),
+        ResNetBlock(make_layer_block(64, 64), gain=gain),
         # 16x16
         ResNetBlock(
             make_layer_block(64, 128, 2, 2),
-            LayerBlock(Conv2d(64, 128, 2, bias=False, stride=2), BatchNorm2d(128)),
-        ),
-        ReLU(),
+            LayerBlock(Conv2d(64, 128, 2, bias=False, stride=2,
+                                gain_weight = gain,
+                                gain_bias = gain), BatchNorm2d(128)),
+        gain=gain),
         ResNetBlock(make_layer_block(128, 128)),
-        ReLU(),
         # 8x8
         ResNetBlock(
             make_layer_block(128, 256, 2, 2),
-            LayerBlock(Conv2d(128, 256, 2, bias=False, stride=2), BatchNorm2d(256)),
-        ),
-        ReLU(),
-        ResNetBlock(make_layer_block(256, 256)),
-        ReLU(),
+            LayerBlock(Conv2d(128, 256, 2, bias=False, stride=2,
+                                gain_weight = gain,
+                                gain_bias = gain), BatchNorm2d(256)),
+        gain=gain),
+        ResNetBlock(make_layer_block(256, 256), gain=gain),
         # 4x4
         ResNetBlock(
             make_layer_block(256, 512, 2, 2),
-            LayerBlock(Conv2d(256, 512, 2, bias=False, stride=2), BatchNorm2d(512)),
-        ),
-        ReLU(),
-        ResNetBlock(make_layer_block(512, 512)),
-        ReLU(),
+            LayerBlock(Conv2d(256, 512, 2, bias=False, stride=2,
+                                gain_weight = gain,
+                                gain_bias = gain), BatchNorm2d(512)),
+        gain=gain),
+        ResNetBlock(make_layer_block(512, 512), gain=gain),
     ]
 
-    final_layers = [AvgPool2d(4), Linear(512, 11)]
+    final_layers = [AvgPool2d(4), Linear(512, 11,
+                                gain_weight = gain,
+                                gain_bias = gain)]
 
     return Sequential(*initial_layers, *resnet_layers, *final_layers)

--- a/src/base_layer.cpp
+++ b/src/base_layer.cpp
@@ -185,11 +185,14 @@ Returns:
 */
 {
     // TODO: Heuristic values!!
-    if (batch_size >= 128 && batch_size < 512) {
-        this->cap_factor_update = 10.0f;
+    if (batch_size >= 32 && batch_size < 64) {
+        this->cap_factor_update = 1.4142f;
     }
-    if (batch_size >= 512) {
-        this->cap_factor_update = 20.0f;
+    if (batch_size >= 64 && batch_size < 256) {
+        this->cap_factor_update = 2.0f;
+    }
+    if (batch_size >= 256) {
+        this->cap_factor_update = 4.0f;
     }
 }
 

--- a/src/base_layer.cpp
+++ b/src/base_layer.cpp
@@ -140,6 +140,9 @@ void BaseLayer::update_weights()
             delta_mu_sign * std::min(std::abs(delta_mu_w[i]), delta_bar);
         this->var_w[i] +=
            delta_var_sign * std::min(std::abs(delta_var_w[i]), delta_bar);
+        if (var_w[i] <= 0.0f) {
+            var_w[i] = 1E-5f;
+        }
     }
 }
 
@@ -161,6 +164,9 @@ void BaseLayer::update_biases()
             this->var_b[i] +=
                             delta_var_sign *
                             std::min(std::abs(this->delta_var_b[i]), delta_bar);
+            if (var_b[i] <= 0.0f) {
+            var_b[i] = 1E-5f;
+        }
         }
     }
 }

--- a/src/base_layer.cpp
+++ b/src/base_layer.cpp
@@ -141,7 +141,7 @@ void BaseLayer::update_weights()
         this->var_w[i] +=
            delta_var_sign * std::min(std::abs(delta_var_w[i]), delta_bar);
         if (var_w[i] <= 0.0f) {
-            var_w[i] = 1E-5f;
+            var_w[i] = 1E-5f; //TODO: replace by a parameter
         }
     }
 }
@@ -165,7 +165,7 @@ void BaseLayer::update_biases()
                             delta_var_sign *
                             std::min(std::abs(this->delta_var_b[i]), delta_bar);
             if (var_b[i] <= 0.0f) {
-            var_b[i] = 1E-5f;
+            var_b[i] = 1E-5f; //TODO: replace by a parameter
         }
         }
     }
@@ -185,14 +185,14 @@ Returns:
 */
 {
     // TODO: Heuristic values!!
-    if (batch_size >= 32 && batch_size < 64) {
-        this->cap_factor_update = 1.4142f;
+    if (batch_size == 1) {
+        this->cap_factor_update = 0.1f;
     }
-    if (batch_size >= 64 && batch_size < 256) {
-        this->cap_factor_update = 2.0f;
+    if (batch_size >1 && batch_size < 256) {
+        this->cap_factor_update = 1.0f;
     }
     if (batch_size >= 256) {
-        this->cap_factor_update = 4.0f;
+        this->cap_factor_update = 2.0f;
     }
 }
 

--- a/src/base_layer_cuda.cu
+++ b/src/base_layer_cuda.cu
@@ -83,7 +83,7 @@ __global__ void device_weight_update(float const *delta_mu_w,
         var_w[col] += delta_var_sign * min(sqrt(tmp_var * tmp_var), delta_bar);
         if (var_w[col] <= 0.0f) {
             var_w[col] = 1E-5f;
-            printf("w"); //Constrain printout for debugging
+            //printf("w"); //Constrain printout for debugging
         }
     }
 }
@@ -106,7 +106,7 @@ __global__ void device_bias_update(float const *delta_mu_b,
         var_b[col] += delta_var_sign * min(fabsf(delta_var_b[col]), delta_bar);
         if (var_b[col] <= 0.0f) {
             var_b[col] = 1E-5f;
-            printf("b"); //Constrain printout for debugging
+            //printf("b"); //Constrain printout for debugging
         }
     }
 }

--- a/src/base_layer_cuda.cu
+++ b/src/base_layer_cuda.cu
@@ -81,6 +81,10 @@ __global__ void device_weight_update(float const *delta_mu_w,
 
         mu_w[col] += delta_mu_sign * min(sqrt(tmp_mu * tmp_mu), delta_bar);
         var_w[col] += delta_var_sign * min(sqrt(tmp_var * tmp_var), delta_bar);
+        if (var_w[col] <= 0.0f) {
+            var_w[col] = 1E-5f;
+            printf("w"); //Constrain printout for debugging
+        }
     }
 }
 
@@ -100,6 +104,10 @@ __global__ void device_bias_update(float const *delta_mu_b,
 
         mu_b[col] += delta_mu_sign * min(fabsf(delta_mu_b[col]), delta_bar);
         var_b[col] += delta_var_sign * min(fabsf(delta_var_b[col]), delta_bar);
+        if (var_b[col] <= 0.0f) {
+            var_b[col] = 1E-5f;
+            printf("b"); //Constrain printout for debugging
+        }
     }
 }
 

--- a/src/norm_layer_cuda.cu
+++ b/src/norm_layer_cuda.cu
@@ -749,7 +749,7 @@ __global__ void batchnorm2d_sample_var_post_processing(float const *data_in,
 {
     int col = blockIdx.x * blockDim.x + threadIdx.x;
     if (col < fi) {
-        data_out[col] = (data_in[col] + bias[col]) / scale;
+        data_out[col] = bias[col] / scale;
     }
 }
 
@@ -799,7 +799,7 @@ BATCH-NORMALIZATION layer whose the previous layer is full-connected layer.
     int row = blockIdx.y * blockDim.y + threadIdx.y;
     int col = blockIdx.x * blockDim.x + threadIdx.x;
     if (col < ni && row < batch_size) {
-        float inv_var_hat = 1.0f / (var_hat[row] + epsilon);
+        float inv_var_hat = 1.0f / (var_hat[col] + epsilon);
         float inv_var_hat_sqrt = sqrtf(inv_var_hat);
         float tmp = mu_w[col] * jcb[col + row * ni];
 

--- a/src/param_init.cpp
+++ b/src/param_init.cpp
@@ -78,7 +78,7 @@ std::tuple<std::vector<float>, std::vector<float>> gaussian_param_init(
     // Weights
     for (int i = 0; i < N; i++) {
         // Variance
-        S[i] = pow(gain * scale, 2);
+        S[i] = gain * pow(scale, 2);
 
         // Get normal distribution
         std::normal_distribution<float> d(0.0f, scale);

--- a/src/param_init.cpp
+++ b/src/param_init.cpp
@@ -78,7 +78,7 @@ std::tuple<std::vector<float>, std::vector<float>> gaussian_param_init(
     // Weights
     for (int i = 0; i < N; i++) {
         // Variance
-        S[i] = gain * pow(scale, 2);
+        S[i] = pow(gain * scale, 2);
 
         // Get normal distribution
         std::normal_distribution<float> d(0.0f, scale);


### PR DESCRIPTION
# Description

This PR 
	1. introduces a check to prevent negative variance updates on the parameters
	2. includes previous Batchnorm bug corrections from https://github.com/lhnguyen102/cuTAGI/tree/bug_batchnorm
	3. moves the gain parameter inside `pow(gain * scale, 2)` for the initialization of the parameters' variances
	4. Switches the order of activation fct and Batchnorm in classification examples
	5. Replaces `ReLU()` by `MixtureleLU()` in classification examples

# Changes Made

1. When the variance resulting from an update step for a parameter is <0, it is replaced bu 1e-5. This removes the need for a scheduler for sigma_v and removes the instability that we were having when training. We can now use much smaller values such as sigma_v=0.1 for training classifiers. Moreover, this allowed reducing  by a factor 10 the `cap_factor` limiting the updates. 
2. The two bugs that were already corrected in the `bug_batchnorm` branch -> `norm_layer_cuda.cu` have been included in this PR as they are essential for a good training performance. 
3. The gain parameter has been moved inside `pow(gain * scale, 2)` in order to allow having a linear control over the scale factor instead of a quadratic one. This will make it easier to adjust the gain for the initialization of the parameters' variances.
I have added the gain parameter explicitly in the ResNet18 architecture in order to enable tuning it to achieve a unit prior predictive variance. A permanent solution for the initialization will come in a future PR.  
4. In the Resnet18-cifar10 example, I placed the `MixtureReLU()` activation function before the `BatchNorm2d()`. This is essential for a good performance. Note that this may be due to a parameter initialization issue that will be treated in a forthcoming PR. 

# Note for Reviewers
You can test the changes on 
ResNet10&CIFAR10
	python -m examples.cifar_resnet_bench
Conv+MNIST
	python -m examples.classification