### PR TITLE
Bugfix - get_input_states working on cuda

### DIFF
--- a/src/sequential.cpp
+++ b/src/sequential.cpp
@@ -777,8 +777,7 @@ Sequential::get_outputs_smoother()
 }
 
 std::tuple<pybind11::array_t<float>, pybind11::array_t<float>>
-Sequential::get_input_states()
-{
+Sequential::get_input_states() {
     // Check if input_state_update is enabled
     if (!this->input_state_update) {
         throw std::invalid_argument("Error in file: " + std::string(__FILE__) +
@@ -786,28 +785,31 @@ Sequential::get_input_states()
                                     ". input_state_update is set to False");
     }
 
+#ifdef USE_CUDA
+    // Output delta_states to host
+    if (this->device.compare("cuda") == 0) {
+        this->delta_z_to_host();
+    }
+#endif
+
     // Define the slice input states size
-    const size_t end_index = this->layers.front()->get_input_size() * this->input_z_buffer->block_size;
+    const size_t end_index = this->layers.front()->get_input_size() *
+                             this->input_z_buffer->block_size;
 
     // Slice delta_mu and delta_var
     std::vector<float> delta_mu_slice(
         this->output_delta_z_buffer->delta_mu.begin(),
-        this->output_delta_z_buffer->delta_mu.begin() + end_index
-    );
+        this->output_delta_z_buffer->delta_mu.begin() + end_index);
 
     std::vector<float> delta_var_slice(
         this->output_delta_z_buffer->delta_var.begin(),
-        this->output_delta_z_buffer->delta_var.begin() + end_index
-    );
+        this->output_delta_z_buffer->delta_var.begin() + end_index);
 
     // Return the slices as pybind11::array_t
-    auto py_delta_mu = pybind11::array_t<float>(
-        delta_mu_slice.size(),
-        delta_mu_slice.data());
-    auto py_delta_var = pybind11::array_t<float>(
-        delta_var_slice.size(),
-        delta_var_slice.data());
+    auto py_delta_mu =
+        pybind11::array_t<float>(delta_mu_slice.size(), delta_mu_slice.data());
+    auto py_delta_var = pybind11::array_t<float>(delta_var_slice.size(),
+                                                 delta_var_slice.data());
 
     return {py_delta_mu, py_delta_var};
 }
-


### PR DESCRIPTION
# Description
This PR includes a bugfix to the previously added method get_input_states. With the new edit the method works properly on GPU.

# Changes Made
- Code refactoring to meet .vsCode style guide.
- In `Sequential.cpp`, `delta_z_to_host` is called in `get_input_states` when the device is set to cuda.

# Note for Reviewers
This method has been previously validated in a PR. The main changes now are between lines 788 and 793 which I had missed before. The method was returning 0 when on cuda, but now it is fixed. As a quick check you can fix the seed on any example and run the same method once on CPU and another on GPU and the results should be identical.