### PR TITLE
bugfix/BaseDeltaState_python_wrapper

### DIFF
--- a/pytagi/nn/data_struct.py
+++ b/pytagi/nn/data_struct.py
@@ -75,7 +75,7 @@ class BaseDeltaStates:
     def delta_var(self) -> List[float]:
         return self._cpp_backend.delta_var
 
-    @delta_mu.setter
+    @delta_var.setter
     def delta_var(self, value: List[float]):
         self._cpp_backend.delta_var = value
 


### PR DESCRIPTION
# Description
This PR corrects the bug in the python wrapper for the `BaseDeltaStates`, i.e. the `delta_var.setter` was incorrectly set to `delta_mu.setter`

# Changes Made
- `pytagi/nn/data_struct.py`

# Note for Reviewers
I needed to use the setter for `BaseDeltaStates` in `canari` so I found this bug