### PR TITLE
Bugfix/batchnorm bias

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -169,10 +169,10 @@ jobs:
         run: |
           sh scripts/compile.sh Release
 
-      - name: Run CPP Test Init
+      - name: Run CPP Test Unit
         run: build/run_tests --cpu
 
-      - name : Run Python Test
+      - name : Run Python Test Unit
         run: python -m test.py_unit.main --cpu
 
   upload_pypi:

--- a/include/norm_layer_cuda.cuh
+++ b/include/norm_layer_cuda.cuh
@@ -9,7 +9,6 @@ class LayerNormCuda : public BaseLayerCuda {
     float *d_mu_ra = nullptr, *d_var_ra = nullptr;
 
     float epsilon;
-    bool bias;
     int _batch_size = 0;
 
     LayerNormCuda(const std::vector<int> &normalized_shape, float eps = 1e-5,
@@ -66,7 +65,6 @@ class BatchNorm2dCuda : public BaseLayerCuda {
     float *d_mu_ra, *d_var_ra, *d_mu_norm_batch, *d_var_norm_batch;
     float epsilon;
     float momentum;
-    bool bias;
 
     // momentum of running average of first batch is set to zero
     bool first_batch = true;

--- a/pytagi/nn/batch_norm.py
+++ b/pytagi/nn/batch_norm.py
@@ -6,7 +6,7 @@ from pytagi.nn.base_layer import BaseLayer
 
 
 class BatchNorm2d(BaseLayer):
-    """Layer normalization"""
+    """Batch normalization"""
 
     def __init__(
         self,

--- a/pytagi/nn/conv2d.py
+++ b/pytagi/nn/conv2d.py
@@ -4,7 +4,7 @@ from pytagi.nn.base_layer import BaseLayer
 
 
 class Conv2d(BaseLayer):
-    """Fully-connected layer"""
+    """Convolutional layer"""
 
     def __init__(
         self,

--- a/pytagi/nn/lstm.py
+++ b/pytagi/nn/lstm.py
@@ -4,7 +4,7 @@ from pytagi.nn.base_layer import BaseLayer
 
 
 class LSTM(BaseLayer):
-    """Fully-connected layer"""
+    """LSTM layer"""
 
     def __init__(
         self,

--- a/pytagi/nn/pooling.py
+++ b/pytagi/nn/pooling.py
@@ -4,7 +4,7 @@ from pytagi.nn.base_layer import BaseLayer
 
 
 class AvgPool2d(BaseLayer):
-    """Fully-connected layer"""
+    """Average Pooling layer"""
 
     def __init__(
         self,

--- a/pytagi/nn/slinear.py
+++ b/pytagi/nn/slinear.py
@@ -2,8 +2,9 @@ import cutagi
 
 from pytagi.nn.base_layer import BaseLayer
 
+
 class SLinear(BaseLayer):
-    """Fully-connected layer"""
+    """Smoothering Linear layer"""
 
     def __init__(
         self,

--- a/pytagi/nn/slstm.py
+++ b/pytagi/nn/slstm.py
@@ -4,7 +4,7 @@ from pytagi.nn.base_layer import BaseLayer
 
 
 class SLSTM(BaseLayer):
-    """Fully-connected layer"""
+    """Smoothing LSTM layer"""
 
     def __init__(
         self,

--- a/src/norm_layer.cpp
+++ b/src/norm_layer.cpp
@@ -328,7 +328,7 @@ void batchnorm_fwd_mean_var(
     const std::vector<float> &mu_b, const std::vector<float> &var_b,
     const std::vector<float> &mu_a, const std::vector<float> &var_a,
     const std::vector<float> &mu_ra, const std::vector<float> &var_ra,
-    float epsilon, int ni, int start_chunk, int end_chunk,
+    bool bias, float epsilon, int ni, int start_chunk, int end_chunk,
     std::vector<float> &mu_z, std::vector<float> &var_z)
 /*Compute mean of product WA of batch-normalization layer.
  */
@@ -339,12 +339,14 @@ void batchnorm_fwd_mean_var(
             float inv_sqrt_var_ra = 1.0f / std::sqrt(var_ra[col] + epsilon);
             float mu_a_tilde = mu_a[idx] - mu_ra[col];
 
-            mu_z[idx] = inv_sqrt_var_ra * mu_a_tilde * mu_w[col] + mu_b[col];
-            var_z[idx] =
-                inv_sqrt_var_ra * inv_sqrt_var_ra *
-                    (var_a[idx] * (mu_w[col] * mu_w[col] + var_w[col]) +
-                     var_w[col] * mu_a_tilde * mu_a_tilde) +
-                var_b[col];
+            mu_z[idx] = inv_sqrt_var_ra * mu_a_tilde * mu_w[col];
+            var_z[idx] = inv_sqrt_var_ra * inv_sqrt_var_ra *
+                         (var_a[idx] * (mu_w[col] * mu_w[col] + var_w[col]) +
+                          var_w[col] * mu_a_tilde * mu_a_tilde);
+            if (bias) {
+                mu_z[idx] += mu_b[col];
+                var_z[idx] += var_b[col];
+            }
         }
     }
 }
@@ -394,7 +396,7 @@ void batchnorm2d_fwd_mean_var(
     const std::vector<float> &mu_b, const std::vector<float> &var_b,
     const std::vector<float> &mu_a, const std::vector<float> &var_a,
     const std::vector<float> &mu_ra, const std::vector<float> &var_ra,
-    float epsilon, int wihi, int fi, int batch_size, int start_chunk,
+    bool bias, float epsilon, int wihi, int fi, int batch_size, int start_chunk,
     int end_chunk, std::vector<float> &mu_z, std::vector<float> &var_z)
 /*Compute mean of product WA of batch-normalization. Note that the previous
 layer is a convolutional layer.
@@ -412,14 +414,17 @@ layer is a convolutional layer.
             int idx = col + row * k;
             float mu_a_tilde = mu_a[idx] - mu_ra_term;
 
-            mu_z[idx] =
-                inv_sqrt_var_ra * mu_a_tilde * mu_w_term + mu_b[row % fi];
+            mu_z[idx] = inv_sqrt_var_ra * mu_a_tilde * mu_w_term;
 
             var_z[idx] =
                 inv_sqrt_var_ra * inv_sqrt_var_ra *
-                    (var_a[idx] * (mu_w_term * mu_w_term + var_w[row % fi]) +
-                     var_w[row % fi] * mu_a_tilde * mu_a_tilde) +
-                var_b[row % fi];
+                (var_a[idx] * (mu_w_term * mu_w_term + var_w[row % fi]) +
+                 var_w[row % fi] * mu_a_tilde * mu_a_tilde);
+
+            if (bias) {
+                mu_z[idx] += mu_b[row % fi];
+                var_z[idx] += var_b[row % fi];
+            }
         }
     }
 }
@@ -1021,7 +1026,7 @@ void batchnorm_fwd_mean_var_mp(
     const std::vector<float> &mu_b, const std::vector<float> &var_b,
     const std::vector<float> &mu_a, const std::vector<float> &var_a,
     const std::vector<float> &mu_ra, const std::vector<float> &var_ra,
-    float epsilon, int ni, int batch_size, const int num_threads,
+    bool bias, float epsilon, int ni, int batch_size, const int num_threads,
     std::vector<float> &mu_z, std::vector<float> &var_z)
 /*Compute mean of product WA of batch-normalization layer.
  */
@@ -1039,8 +1044,8 @@ void batchnorm_fwd_mean_var_mp(
         threads.emplace_back([=, &mu_w, &var_w, &mu_b, &var_b, &mu_a, &var_a,
                               &mu_ra, &var_ra, &mu_z, &var_z] {
             batchnorm_fwd_mean_var(mu_w, var_w, mu_b, var_b, mu_a, var_a, mu_ra,
-                                   var_ra, epsilon, ni, start_chunk, end_chunk,
-                                   mu_z, var_z);
+                                   var_ra, bias, epsilon, ni, start_chunk,
+                                   end_chunk, mu_z, var_z);
         });
     }
 
@@ -1118,8 +1123,8 @@ void batchnorm2d_fwd_mean_var_mp(
     const std::vector<float> &mu_b, const std::vector<float> &var_b,
     const std::vector<float> &mu_a, const std::vector<float> &var_a,
     const std::vector<float> &mu_ra, const std::vector<float> &var_ra,
-    float epsilon, int wihi, int fi, int batch_size, const int num_threads,
-    std::vector<float> &mu_z, std::vector<float> &var_z)
+    bool bias, float epsilon, int wihi, int fi, int batch_size,
+    const int num_threads, std::vector<float> &mu_z, std::vector<float> &var_z)
 /*Compute mean of product WA of batch-normalization. Note that the previous
 layer is a convolutional layer.
 */
@@ -1136,9 +1141,10 @@ layer is a convolutional layer.
 
         threads.emplace_back([=, &mu_w, &var_w, &mu_b, &var_b, &mu_a, &var_a,
                               &mu_ra, &var_ra, &mu_z, &var_z] {
-            batchnorm2d_fwd_mean_var(
-                mu_w, var_w, mu_b, var_b, mu_a, var_a, mu_ra, var_ra, epsilon,
-                wihi, fi, batch_size, start_chunk, end_chunk, mu_z, var_z);
+            batchnorm2d_fwd_mean_var(mu_w, var_w, mu_b, var_b, mu_a, var_a,
+                                     mu_ra, var_ra, bias, epsilon, wihi, fi,
+                                     batch_size, start_chunk, end_chunk, mu_z,
+                                     var_z);
         });
     }
 
@@ -1922,7 +1928,7 @@ void BatchNorm2d::forward(BaseHiddenStates &input_states,
             batchnorm_fwd_mean_var(
                 this->mu_w, this->var_w, this->mu_b, this->var_b,
                 input_states.mu_a, input_states.var_a, mu_target, var_target,
-                this->epsilon, this->input_size, 0, batch_size,
+                this->bias, this->epsilon, this->input_size, 0, batch_size,
                 output_states.mu_a, output_states.var_a);
 
         } else {
@@ -1946,8 +1952,8 @@ void BatchNorm2d::forward(BaseHiddenStates &input_states,
             batchnorm2d_fwd_mean_var(
                 this->mu_w, this->var_w, this->mu_b, this->var_b,
                 input_states.mu_a, input_states.var_a, mu_target, var_target,
-                this->epsilon, wihi, this->in_channels, batch_size, 0,
-                end_chunk, output_states.mu_a, output_states.var_a);
+                this->bias, this->epsilon, wihi, this->in_channels, batch_size,
+                0, end_chunk, output_states.mu_a, output_states.var_a);
         }
     } else {
         if (this->num_features != this->in_channels) {
@@ -1969,8 +1975,8 @@ void BatchNorm2d::forward(BaseHiddenStates &input_states,
             batchnorm_fwd_mean_var_mp(
                 this->mu_w, this->var_w, this->mu_b, this->var_b,
                 input_states.mu_a, input_states.var_a, mu_target, var_target,
-                this->epsilon, this->input_size, batch_size, this->num_threads,
-                output_states.mu_a, output_states.var_a);
+                this->bias, this->epsilon, this->input_size, batch_size,
+                this->num_threads, output_states.mu_a, output_states.var_a);
 
         } else {
             int wihi = this->in_height * this->in_width;
@@ -1995,7 +2001,7 @@ void BatchNorm2d::forward(BaseHiddenStates &input_states,
             batchnorm2d_fwd_mean_var_mp(
                 this->mu_w, this->var_w, this->mu_b, this->var_b,
                 input_states.mu_a, input_states.var_a, mu_target, var_target,
-                this->epsilon, wihi, this->in_channels, batch_size,
+                this->bias, this->epsilon, wihi, this->in_channels, batch_size,
                 this->num_threads, output_states.mu_a, output_states.var_a);
         }
     }
@@ -2087,7 +2093,7 @@ void BatchNorm2d::backward(BaseDeltaStates &input_delta_states,
                                 this->in_channels, batch_size, this->delta_mu_w,
                                 this->delta_var_w);
 
-                if (this->num_biases > 0) {
+                if (this->bias) {
                     batchnorm2d_bwd_delta_b(
                         this->var_b, input_delta_states.delta_mu,
                         input_delta_states.delta_var, this->epsilon, wihi,
@@ -2131,7 +2137,7 @@ void BatchNorm2d::backward(BaseDeltaStates &input_delta_states,
                                 this->in_channels, batch_size, this->delta_mu_w,
                                 this->delta_var_w);
 
-                if (this->num_biases > 0) {
+                if (this->bias) {
                     batchnorm2d_bwd_delta_b_mp(
                         this->var_b, input_delta_states.delta_mu,
                         input_delta_states.delta_var, this->epsilon, wihi,

--- a/test/cpp_unit/test_mnist.cpp
+++ b/test/cpp_unit/test_mnist.cpp
@@ -284,6 +284,21 @@ class MnistTest : public ::testing::Test {
         return true;
     }
 };
+
+TEST_F(MnistTest, BatchnormWithoutBiases_CPU) {
+    Sequential model(Conv2d(1, 8, 4, false, 1, 1, 1, 28, 28),
+                     BatchNorm2d(8, 1e-5, 0, false), ReLU(), AvgPool2d(3, 2),
+                     Conv2d(8, 8, 5, false), BatchNorm2d(8, 1e-5, 0, false),
+                     ReLU(), AvgPool2d(3, 2), Linear(8 * 4 * 4, 32), ReLU(),
+                     Linear(32, 11));
+    model.set_threads(2);
+
+    float avg_error;
+    float threshold = 0.5;
+    mnist_test_runner(model, avg_error);
+    EXPECT_LT(avg_error, threshold) << "Error rate is higher than threshold";
+}
+
 TEST_F(MnistTest, FNNModelTest_CPU) {
     Sequential model(Linear(784, 32), ReLU(), Linear(32, 32), ReLU(),
                      Linear(32, 11));
@@ -368,6 +383,21 @@ TEST_F(MnistTest, MismatchSizeDetection) {
 }
 
 #ifdef USE_CUDA
+TEST_F(MnistTest, BatchnormWithoutBiases_CUDA) {
+    if (!g_gpu_enabled) GTEST_SKIP() << "GPU tests are disabled.";
+    Sequential model(Conv2d(1, 8, 4, false, 1, 1, 1, 28, 28),
+                     BatchNorm2d(8, 1e-5, 0, false), ReLU(), AvgPool2d(3, 2),
+                     Conv2d(8, 8, 5, false), BatchNorm2d(8, 1e-5, 0, false),
+                     ReLU(), AvgPool2d(3, 2), Linear(8 * 4 * 4, 32), ReLU(),
+                     Linear(32, 11));
+    model.to_device("cuda");
+
+    float avg_error;
+    float threshold = 0.5;
+    mnist_test_runner(model, avg_error);
+    EXPECT_LT(avg_error, threshold) << "Error rate is higher than threshold";
+}
+
 TEST_F(MnistTest, FNNModelTest_CUDA) {
     if (!g_gpu_enabled) GTEST_SKIP() << "GPU tests are disabled.";
     Sequential model(Linear(784, 32), ReLU(), Linear(32, 32), ReLU(),

--- a/test/cpp_unit/test_mnist.cpp
+++ b/test/cpp_unit/test_mnist.cpp
@@ -291,7 +291,7 @@ TEST_F(MnistTest, BatchnormWithoutBiases_CPU) {
                      Conv2d(8, 8, 5, false), BatchNorm2d(8, 1e-5, 0, false),
                      ReLU(), AvgPool2d(3, 2), Linear(8 * 4 * 4, 32), ReLU(),
                      Linear(32, 11));
-    model.set_threads(2);
+    model.set_threads(4);
 
     float avg_error;
     float threshold = 0.5;
@@ -340,7 +340,7 @@ TEST_F(MnistTest, CNNTest_CPU) {
     Sequential model(Conv2d(1, 8, 4, true, 1, 1, 1, 28, 28), ReLU(),
                      AvgPool2d(3, 2), Conv2d(8, 8, 5), ReLU(), AvgPool2d(3, 2),
                      Linear(8 * 4 * 4, 32), ReLU(), Linear(32, 11));
-    model.set_threads(2);
+    model.set_threads(4);
 
     float avg_error;
     float threshold = 0.5;
@@ -353,7 +353,7 @@ TEST_F(MnistTest, BatchNormCNNTest_CPU) {
                      ReLU(), AvgPool2d(3, 2), Conv2d(8, 8, 5, false),
                      BatchNorm2d(8), ReLU(), AvgPool2d(3, 2),
                      Linear(8 * 4 * 4, 32), ReLU(), Linear(32, 11));
-    model.set_threads(2);
+    model.set_threads(4);
 
     float avg_error;
     float threshold = 0.5;
@@ -388,6 +388,22 @@ TEST_F(MnistTest, BatchnormWithoutBiases_CUDA) {
     Sequential model(Conv2d(1, 8, 4, false, 1, 1, 1, 28, 28),
                      BatchNorm2d(8, 1e-5, 0, false), ReLU(), AvgPool2d(3, 2),
                      Conv2d(8, 8, 5, false), BatchNorm2d(8, 1e-5, 0, false),
+                     ReLU(), AvgPool2d(3, 2), Linear(8 * 4 * 4, 32), ReLU(),
+                     Linear(32, 11));
+    model.to_device("cuda");
+
+    float avg_error;
+    float threshold = 0.5;
+    mnist_test_runner(model, avg_error);
+    EXPECT_LT(avg_error, threshold) << "Error rate is higher than threshold";
+}
+
+TEST_F(MnistTest, LayernormWithoutBiases_CUDA) {
+    if (!g_gpu_enabled) GTEST_SKIP() << "GPU tests are disabled.";
+    Sequential model(Conv2d(1, 8, 4, false, 1, 1, 1, 28, 28),
+                     LayerNorm(std::vector<int>({8, 27, 27}), 1e-5, false),
+                     ReLU(), AvgPool2d(3, 2), Conv2d(8, 8, 5, false),
+                     LayerNorm(std::vector<int>({8, 9, 9}), 1e-5, false),
                      ReLU(), AvgPool2d(3, 2), Linear(8 * 4 * 4, 32), ReLU(),
                      Linear(32, 11));
     model.to_device("cuda");

--- a/test/py_unit/test_mnist.py
+++ b/test/py_unit/test_mnist.py
@@ -119,6 +119,21 @@ class MnistTest(unittest.TestCase):
             avg_error_rate, self.threshold, "Error rate is higher than threshold"
         )
 
+    def test_batchnorm_without_bias_fnn_CPU(self):
+        model = Sequential(
+            Linear(784, 32),
+            BatchNorm2d(32, bias=False),
+            ReLU(),
+            Linear(32, 32),
+            BatchNorm2d(32, bias=False),
+            ReLU(),
+            Linear(32, 11),
+        )
+        avg_error_rate = mnist_test_runner(model)
+        self.assertLess(
+            avg_error_rate, self.threshold, "Error rate is higher than threshold"
+        )
+
     def test_layernorm_fnn_CPU(self):
         model = Sequential(
             Linear(784, 32),


### PR DESCRIPTION
## Description

This PR fixed bug in layer/batch norms for the case where don't want to use bias. 

## Changes Made

- Added `bool bias` to forward pass for batch/layer norms in order to handle the case where bias is disable
- Removed member class `bias` in `norm_layer_cuda.cu` because it is defined in the base layer
- Added unittest for both CPP  and Python for testing the batch/layer norms without biases
- Corrected the wrong description in pytagi package

## Related Issue(s)
Closes #102 
## Checklist

- [x]  I have followed the project's coding conventions and style guidelines.
- [x]  I have updated the documentation, if applicable.
- [x]  I have rebased my branch on the latest upstream code to incorporate any changes.
- [x]  I have tested the changes locally.


## Notes for Reviewers

Here are the command to run the test without bias for both layer and batch norms
CPP
```bash
build/run_tests --gtest_filter=MnistTest.BatchnormWithoutBiases_CPU
build/run_tests --gtest_filter=MnistTest.BatchnormWithoutBiases_CUDA
build/run_tests --gtest_filter=MnistTest.LayernormWithoutBiases_CUDA
```
Python
```bash
python -m test.py_unit.main
```
You should see something like this
```bash
...
test_batchnorm_without_bias_fnn_CPU (test.py_unit.test_mnist.MnistTest.test_batchnorm_without_bias_fnn_CPU) ... ok
....
```