### PR TITLE
Hotfix/cuda availability check

### DIFF
--- a/examples/cifar_resnet_bench.py
+++ b/examples/cifar_resnet_bench.py
@@ -253,8 +253,13 @@ def tagi_trainer(
         for x, labels in train_loader:
             # Feedforward and backward pass
             m_pred, v_pred = net(x)
-            if print_var: # Print prior predictive variance
-                print("Prior predictive -> E[v_pred] = ", np.average(v_pred), "+-", np.std(v_pred))
+            if print_var:  # Print prior predictive variance
+                print(
+                    "Prior predictive -> E[v_pred] = ",
+                    np.average(v_pred),
+                    "+-",
+                    np.std(v_pred),
+                )
                 print_var = False
 
             # Update output layers based on targets

--- a/examples/classification.py
+++ b/examples/classification.py
@@ -1,9 +1,18 @@
+# Temporary import. It will be removed in the final vserion
+import os
+import sys
+
+# Add the 'build' directory to sys.path in one line
+sys.path.append(
+    os.path.normpath(os.path.join(os.path.dirname(__file__), "..", "build"))
+)
 import fire
 import numpy as np
 from tqdm import tqdm
 
 from examples.data_loader import MnistDataLoader
 from pytagi import HRCSoftmaxMetric
+import pytagi
 from pytagi.nn import (
     AvgPool2d,
     BatchNorm2d,
@@ -107,7 +116,8 @@ def main(num_epochs: int = 10, batch_size: int = 128, sigma_v: float = 0.1):
 
     # Network configuration
     net = FNN
-    # net.to_device("cuda")
+    if pytagi.cuda.is_available():
+        net.to_device("cuda")
     # net.set_threads(16)
     out_updater = OutputUpdater(net.device)
 

--- a/examples/classification.py
+++ b/examples/classification.py
@@ -1,11 +1,3 @@
-# Temporary import. It will be removed in the final vserion
-import os
-import sys
-
-# Add the 'build' directory to sys.path in one line
-sys.path.append(
-    os.path.normpath(os.path.join(os.path.dirname(__file__), "..", "build"))
-)
 import fire
 import numpy as np
 from tqdm import tqdm

--- a/examples/regression_heteros.py
+++ b/examples/regression_heteros.py
@@ -11,6 +11,7 @@ from pytagi.nn import Linear, OutputUpdater, ReLU, Sequential, EvenExp
 
 np.random.seed(0)
 
+
 def main(num_epochs: int = 50, batch_size: int = 10):
     """Run training for the regression"""
     # Dataset
@@ -30,7 +31,9 @@ def main(num_epochs: int = 50, batch_size: int = 10):
     )
 
     # Viz
-    viz = PredictionViz(task_name="heteros regression", data_name="1d_toy_noise")
+    viz = PredictionViz(
+        task_name="heteros regression", data_name="1d_toy_noise"
+    )
 
     cuda = True
 
@@ -39,7 +42,12 @@ def main(num_epochs: int = 50, batch_size: int = 10):
     print(pytagi.is_cuda_available())
 
     net = Sequential(
-        Linear(1, 128), ReLU(), Linear(128, 128), ReLU(), Linear(128, 2), EvenExp()
+        Linear(1, 128),
+        ReLU(),
+        Linear(128, 128),
+        ReLU(),
+        Linear(128, 2),
+        EvenExp(),
     )
     if cuda:
         net.to_device("cuda")
@@ -70,7 +78,9 @@ def main(num_epochs: int = 50, batch_size: int = 10):
             net.step()
 
             # Training metric
-            pred = Normalizer.unstandardize(m_pred, train_dtl.y_mean, train_dtl.y_std)
+            pred = Normalizer.unstandardize(
+                m_pred, train_dtl.y_mean, train_dtl.y_std
+            )
             obs = Normalizer.unstandardize(y, train_dtl.y_mean, train_dtl.y_std)
 
             # Even positions correspond to Z_out
@@ -110,7 +120,9 @@ def main(num_epochs: int = 50, batch_size: int = 10):
     y_test = np.array(y_test)
     x_test = np.array(x_test)
 
-    mu_preds = Normalizer.unstandardize(mu_preds, train_dtl.y_mean, train_dtl.y_std)
+    mu_preds = Normalizer.unstandardize(
+        mu_preds, train_dtl.y_mean, train_dtl.y_std
+    )
     std_preds = Normalizer.unstandardize_std(std_preds, train_dtl.y_std)
 
     x_test = Normalizer.unstandardize(x_test, train_dtl.x_mean, train_dtl.x_std)

--- a/examples/tagi_resnet_model.py
+++ b/examples/tagi_resnet_model.py
@@ -10,7 +10,14 @@ from pytagi.nn import (
 )
 
 
-def make_layer_block(in_c: int, out_c: int, stride: int = 1, padding_type: int = 1, gain_weight: float = 1, gain_bias: float = 1):
+def make_layer_block(
+    in_c: int,
+    out_c: int,
+    stride: int = 1,
+    padding_type: int = 1,
+    gain_weight: float = 1,
+    gain_bias: float = 1,
+):
     """Create a layer block for resnet 18"""
 
     return LayerBlock(
@@ -22,17 +29,20 @@ def make_layer_block(in_c: int, out_c: int, stride: int = 1, padding_type: int =
             stride=stride,
             padding=1,
             padding_type=padding_type,
-            gain_weight = gain_weight,
-            gain_bias = gain_bias,
+            gain_weight=gain_weight,
+            gain_bias=gain_bias,
         ),
         MixtureReLU(),
         BatchNorm2d(out_c),
-        Conv2d(out_c,
-               out_c, 3,
-               bias=False,
-               padding=1,
-               gain_weight = gain_weight,
-               gain_bias = gain_bias),
+        Conv2d(
+            out_c,
+            out_c,
+            3,
+            bias=False,
+            padding=1,
+            gain_weight=gain_weight,
+            gain_bias=gain_bias,
+        ),
         MixtureReLU(),
         BatchNorm2d(out_c),
     )
@@ -42,12 +52,17 @@ def resnet18_cifar10(gain_w: float = 1, gain_b: float = 1) -> Sequential:
     """Resnet18 architecture for cifar10"""
     # 32x32
     initial_layers = [
-        Conv2d(3, 64, 3,
-               bias=False,
-               padding=1,
-               in_width=32, in_height=32,
-               gain_weight = gain_w,
-               gain_bias = gain_b),
+        Conv2d(
+            3,
+            64,
+            3,
+            bias=False,
+            padding=1,
+            in_width=32,
+            in_height=32,
+            gain_weight=gain_w,
+            gain_bias=gain_b,
+        ),
         MixtureReLU(),
         BatchNorm2d(64),
     ]
@@ -59,31 +74,56 @@ def resnet18_cifar10(gain_w: float = 1, gain_b: float = 1) -> Sequential:
         # 16x16
         ResNetBlock(
             make_layer_block(64, 128, 2, 2, gain_weight=gain_w, gain_bias=gain_b),
-            LayerBlock(Conv2d(64, 128, 2, bias=False, stride=2,
-            gain_weight = gain_w,
-            gain_bias = gain_b), BatchNorm2d(128))
+            LayerBlock(
+                Conv2d(
+                    64,
+                    128,
+                    2,
+                    bias=False,
+                    stride=2,
+                    gain_weight=gain_w,
+                    gain_bias=gain_b,
+                ),
+                BatchNorm2d(128),
+            ),
         ),
         ResNetBlock(make_layer_block(128, 128, gain_weight=gain_w, gain_bias=gain_b)),
         # 8x8
         ResNetBlock(
             make_layer_block(128, 256, 2, 2, gain_weight=gain_w, gain_bias=gain_b),
-            LayerBlock(Conv2d(128, 256, 2, bias=False, stride=2,
-            gain_weight = gain_w,
-            gain_bias = gain_b), BatchNorm2d(256))
+            LayerBlock(
+                Conv2d(
+                    128,
+                    256,
+                    2,
+                    bias=False,
+                    stride=2,
+                    gain_weight=gain_w,
+                    gain_bias=gain_b,
+                ),
+                BatchNorm2d(256),
+            ),
         ),
         ResNetBlock(make_layer_block(256, 256, gain_weight=gain_w, gain_bias=gain_b)),
         # 4x4
         ResNetBlock(
             make_layer_block(256, 512, 2, 2, gain_weight=gain_w, gain_bias=gain_b),
-            LayerBlock(Conv2d(256, 512, 2, bias=False, stride=2,
-            gain_weight = gain_w,
-            gain_bias = gain_b), BatchNorm2d(512))
+            LayerBlock(
+                Conv2d(
+                    256,
+                    512,
+                    2,
+                    bias=False,
+                    stride=2,
+                    gain_weight=gain_w,
+                    gain_bias=gain_b,
+                ),
+                BatchNorm2d(512),
+            ),
         ),
-        ResNetBlock(make_layer_block(512, 512, gain_weight=gain_w, gain_bias=gain_b))
+        ResNetBlock(make_layer_block(512, 512, gain_weight=gain_w, gain_bias=gain_b)),
     ]
 
-    final_layers = [AvgPool2d(4),
-                    Linear(512, 11, gain_weight = gain_b, gain_bias = gain_b)
-    ]
+    final_layers = [AvgPool2d(4), Linear(512, 11, gain_weight=gain_b, gain_bias=gain_b)]
 
     return Sequential(*initial_layers, *resnet_layers, *final_layers)

--- a/pytagi/__init__.py
+++ b/pytagi/__init__.py
@@ -1,4 +1,5 @@
 from pytagi.tagi_utils import Normalizer, HRCSoftmax, Utils, exponential_scheduler
 from pytagi.metric import HRCSoftmaxMetric
 from .__version import __version__
-from cutagi import manual_seed, is_cuda_available
+from cutagi import manual_seed
+import pytagi.cuda as cuda

--- a/pytagi/cuda.py
+++ b/pytagi/cuda.py
@@ -1,0 +1,10 @@
+import cutagi
+
+
+def is_available() -> bool:
+    """Check if CUDA is available
+
+    Returns:
+        bool: True if CUDA is available, False otherwise
+    """
+    return cutagi.is_cuda_available()

--- a/pytagi/nn/linear.py
+++ b/pytagi/nn/linear.py
@@ -35,4 +35,3 @@ class Linear(BaseLayer):
 
     def init_weight_bias(self):
         self._cpp_backend.init_weight_bias()
-

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -2,6 +2,10 @@
 
 #include "../include/custom_logger.h"
 
+#ifdef USE_CUDA
+#include <cuda_runtime.h>
+#endif
+
 std::string get_current_dir() {
     char buff[FILENAME_MAX];  // create string buffer to hold path
     GetCurrentDir(buff, FILENAME_MAX);
@@ -355,7 +359,15 @@ std::mt19937 &get_random_engine() {
 ///////////////////////////////////////////////////////
 bool is_cuda_available() {
 #ifdef USE_CUDA
-    return true;
+    int deviceCount = 0;
+    cudaError_t error = cudaGetDeviceCount(&deviceCount);
+
+    if (error != cudaSuccess) {
+        std::cerr << "CUDA runtime error: " << cudaGetErrorString(error)
+                  << std::endl;
+        return false;
+    }
+    return deviceCount > 0;
 #else
     return false;
 #endif

--- a/test/py_unit/test_fnn_heteros.py
+++ b/test/py_unit/test_fnn_heteros.py
@@ -4,6 +4,7 @@ import unittest
 
 import numpy as np
 
+import pytagi
 import pytagi.metric as metric
 from examples.data_loader import RegressionDataLoader
 from pytagi import Normalizer
@@ -11,7 +12,9 @@ from pytagi.nn import EvenExp, Linear, OutputUpdater, ReLU, Sequential
 
 # path to binding code
 sys.path.append(
-    os.path.normpath(os.path.join(os.path.dirname(__file__), "..", "..", "build"))
+    os.path.normpath(
+        os.path.join(os.path.dirname(__file__), "..", "..", "build")
+    )
 )
 
 TEST_CPU_ONLY = os.getenv("TEST_CPU_ONLY") == "1"
@@ -56,7 +59,9 @@ def heteros_test_runner(
             model.step()
 
             # Training metric
-            pred = Normalizer.unstandardize(m_pred, train_dtl.y_mean, train_dtl.y_std)
+            pred = Normalizer.unstandardize(
+                m_pred, train_dtl.y_mean, train_dtl.y_std
+            )
             obs = Normalizer.unstandardize(y, train_dtl.y_mean, train_dtl.y_std)
 
             # Even positions correspond to Z_out
@@ -75,18 +80,34 @@ class SineSignalHeterosTest(unittest.TestCase):
 
     def test_heteros_CPU(self):
         model = Sequential(
-            Linear(1, 32), ReLU(), Linear(32, 32), ReLU(), Linear(32, 2), EvenExp()
+            Linear(1, 32),
+            ReLU(),
+            Linear(32, 32),
+            ReLU(),
+            Linear(32, 2),
+            EvenExp(),
         )
         mse = heteros_test_runner(model)
-        self.assertLess(mse, self.threshold, "Error rate is higher than threshold")
+        self.assertLess(
+            mse, self.threshold, "Error rate is higher than threshold"
+        )
 
     @unittest.skipIf(TEST_CPU_ONLY, "Skipping CUDA tests due to --cpu flag")
     def test_heteros_CUDA(self):
+        if not pytagi.cuda.is_available():
+            self.skipTest("CUDA is not available")
         model = Sequential(
-            Linear(1, 32), ReLU(), Linear(32, 32), ReLU(), Linear(32, 2), EvenExp()
+            Linear(1, 32),
+            ReLU(),
+            Linear(32, 32),
+            ReLU(),
+            Linear(32, 2),
+            EvenExp(),
         )
         mse = heteros_test_runner(model, use_cuda=True)
-        self.assertLess(mse, self.threshold, "Error rate is higher than threshold")
+        self.assertLess(
+            mse, self.threshold, "Error rate is higher than threshold"
+        )
 
 
 if __name__ == "__main__":

--- a/test/py_unit/test_lstm.py
+++ b/test/py_unit/test_lstm.py
@@ -4,6 +4,7 @@ import unittest
 
 import numpy as np
 
+import pytagi
 import pytagi.metric as metric
 from examples.data_loader import TimeSeriesDataloader
 from pytagi import Normalizer as normalizer
@@ -204,6 +205,8 @@ class SineSignalTest(unittest.TestCase):
 
     @unittest.skipIf(TEST_CPU_ONLY, "Skipping CUDA tests due to --cpu flag")
     def test_lstm_CUDA(self):
+        if not pytagi.cuda.is_available():
+            self.skipTest("CUDA is not available")
         input_seq_len = 4
         model = Sequential(
             LSTM(1, 8, input_seq_len),

--- a/test/py_unit/test_mnist.py
+++ b/test/py_unit/test_mnist.py
@@ -4,6 +4,7 @@ import unittest
 
 import numpy as np
 
+import pytagi
 from examples.data_loader import MnistDataLoader
 from pytagi import HRCSoftmaxMetric
 from pytagi.nn import (
@@ -229,6 +230,8 @@ class MnistTest(unittest.TestCase):
     # CUDA Tests
     @unittest.skipIf(TEST_CPU_ONLY, "Skipping CUDA tests due to --cpu flag")
     def test_fnn_CUDA(self):
+        if not pytagi.cuda.is_available():
+            self.skipTest("CUDA is not available")
         model = Sequential(
             Linear(784, 32), ReLU(), Linear(32, 32), ReLU(), Linear(32, 11)
         )
@@ -239,6 +242,8 @@ class MnistTest(unittest.TestCase):
 
     @unittest.skipIf(TEST_CPU_ONLY, "Skipping CUDA tests due to --cpu flag")
     def test_mixturerelu_CUDA(self):
+        if not pytagi.cuda.is_available():
+            self.skipTest("CUDA is not available")
         model = Sequential(
             Linear(784, 32),
             MixtureReLU(),
@@ -253,6 +258,8 @@ class MnistTest(unittest.TestCase):
 
     @unittest.skipIf(TEST_CPU_ONLY, "Skipping CUDA tests due to --cpu flag")
     def test_batchnorm_fnn_CUDA(self):
+        if not pytagi.cuda.is_available():
+            self.skipTest("CUDA is not available")
         model = Sequential(
             Linear(784, 32),
             BatchNorm2d(32),
@@ -269,6 +276,8 @@ class MnistTest(unittest.TestCase):
 
     @unittest.skipIf(TEST_CPU_ONLY, "Skipping CUDA tests due to --cpu flag")
     def test_layernorm_fnn_CUDA(self):
+        if not pytagi.cuda.is_available():
+            self.skipTest("CUDA is not available")
         model = Sequential(
             Linear(784, 32),
             ReLU(),
@@ -285,6 +294,8 @@ class MnistTest(unittest.TestCase):
 
     @unittest.skipIf(TEST_CPU_ONLY, "Skipping CUDA tests due to --cpu flag")
     def test_cnn_CUDA(self):
+        if not pytagi.cuda.is_available():
+            self.skipTest("CUDA is not available")
         model = Sequential(
             Conv2d(
                 1, 8, 4, padding=1, stride=1, padding_type=1, in_width=28, in_height=28


### PR DESCRIPTION
## Description

This PR fixed the bug in cuda availability check in order to take into account the case where the binary code might be compiled with cuda option `USE_CUDA=true` but the host device's cuda is not available. 

## Changes Made

- Added new check to `common.h` for cuda device checking
- Added the cuda check to python unittest
- Fixed black format for some python files

## Checklist

- [x]  I have followed the project's coding conventions and style guidelines.
- [x]  I have updated the documentation, if applicable.
- [x]  I have rebased my branch on the latest upstream code to incorporate any changes.
- [x]  I have tested the changes locally.


## Notes for Reviewers

Here is the command to run the test
```sh
python -m test.py_unit.main
```
We expect that it will skip the CUDA test in macOS or ubuntu without cuda even though we don't explicitly provide the `--cpu` flag