### PR TITLE
Feature/resnet18 imagenet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ dist
 data/cifar
 data/mnist/
 data/traffic
+data/imagenet
 test_model/
 
 # VSCode

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,7 +8,5 @@ graft extern/pybind11/include
 graft extern/pybind11/tools
 include LICENSE README.md pyproject.toml setup.py setup.cfg
 include pytagi/version.txt
-include extern/action_scripts/install_cuda_ubuntu.sh
-include extern/action_scripts/LICENSE
 include extern/pybind11/LICENSE
 global-include CMakeLists.txt *.cmake

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -194,7 +194,7 @@ This guide covers detailed instructions on installing both `pytagi` and `cuTAGI`
    ```
 
    Replace `[option]` with one of the following:
-   - `Release`: For optimized release build
+   - `Release`: For optimized release build (Default)
    - `ReleaseWithInfo`: For release build with debug information
    - `Debug`: For debug build using GDB Debugger
 

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -104,6 +104,12 @@ This guide covers detailed instructions on installing both `pytagi` and `cuTAGI`
 
 4. **Install `pytagi` Locally**:
 
+   Remove cache
+   ```sh
+   pip cache purge
+   ```
+
+   Install package
    ```sh
    pip install .
    ```

--- a/docs/download_imagenet.md
+++ b/docs/download_imagenet.md
@@ -4,11 +4,9 @@
 
 Before running the downloading script, ensure the following tools are installed
 
-1. **Navigate to `cuTAGI` folder**
+1. **Kaggle CLI** (activate Python environment and install using `pip install kaggle`)
 
-2. **Kaggle CLI** (activate Python environment and install using `pip install kaggle`)
-
-3. **Kaggle API Key**:
+2. **Kaggle API Key**:
    - Go to your [Kaggle Account Settings](https://www.kaggle.com/account).
    - Create and download an API token (`kaggle.json`).
 
@@ -62,20 +60,22 @@ Before running the downloading script, ensure the following tools are installed
 
 Follow these steps to download the ImageNet dataset:
 
-1. **Make Script Executable**:
+1. **Navigate to `cuTAGI` folder**
+
+2. **Make Script Executable**:
    ```bash
    chmod +x scripts/download_imagenet.sh
    ```
 
-2. **Run Script**:
+4. **Run Script**:
    ```bash
    scripts/download_imagenet.sh
    ```
 
-3. **Data Location**:
+4. **Data Location**:
    - The ImageNet dataset will be downloaded and extracted into the `imagenet_data` directory.
 
-4. **Convert Validation Dataset for PyTorch**:
+5. **Convert Validation Dataset for PyTorch**:
    - Navigate to the validation data directory:
      ```bash
      cd ILSVRC/Data/CLS-LOC/val

--- a/docs/download_imagenet.md
+++ b/docs/download_imagenet.md
@@ -62,12 +62,12 @@ Before running the downloading script, ensure the following tools are installed
 
 Follow these steps to download the ImageNet dataset:
 
-1. **Make the script executable**:
+1. **Make Script Executable**:
    ```bash
    chmod +x scripts/download_imagenet.sh
    ```
 
-2. **Run the script**:
+2. **Run Script**:
    ```bash
    scripts/download_imagenet.sh
    ```

--- a/docs/download_imagenet.md
+++ b/docs/download_imagenet.md
@@ -84,3 +84,9 @@ Follow these steps to download the ImageNet dataset:
      ```bash
      wget -qO- https://raw.githubusercontent.com/soumith/imagenetloader.torch/master/valprep.sh | bash
      ```
+6. **Clean Up Kaggle API Key If Running on Server**:
+
+   For security, remove the `kaggle.json` file from the server after downloading:
+    ```bash
+    rm -rf ~/.kaggle
+    ```

--- a/docs/download_imagenet.md
+++ b/docs/download_imagenet.md
@@ -1,0 +1,83 @@
+# ImageNet Data Download Script
+
+## Prerequisites
+
+Before running the downloading script, ensure the following tools are installed
+
+1. **Kaggle CLI** (install using `pip install kaggle`)
+
+2. **Kaggle API Key**:
+   - Go to your [Kaggle Account Settings](https://www.kaggle.com/account).
+   - Create and download an API token (`kaggle.json`).
+
+   ### If Running Locally:
+   - Save the `kaggle.json` file to the directory `~/.kaggle/`:
+     ```bash
+     mkdir -p ~/.kaggle
+     mv ~/Downloads/kaggle.json ~/.kaggle/
+     chmod 600 ~/.kaggle/kaggle.json
+     ```
+
+   ### If Running on a Server:
+   Follow these steps to transfer your `kaggle.json` file to the server:
+   1. **Locate the `kaggle.json` File**:
+      - The `kaggle.json` file is typically downloaded to your local `Downloads` folder after generating an API token.
+
+   2. **Transfer the File to the Server**:
+      - Use the `scp` command:
+        ```bash
+        scp ~/Downloads/kaggle.json <username>@<server-ip>:~
+        ```
+        Replace:
+        - `~/Downloads/kaggle.json` with the path to your `kaggle.json` file.
+        - `<username>` with your server's username.
+        - `<server-ip>` with the server's IP address.
+
+   3. **Move the File to the Correct Directory**:
+      - Log in to your server:
+        ```bash
+        ssh <username>@<server-ip>
+        ```
+      - Create the `.kaggle` directory and move the file:
+        ```bash
+        mkdir -p ~/.kaggle
+        mv ~/kaggle.json ~/.kaggle/
+        ```
+      - Secure the file by setting appropriate permissions:
+        ```bash
+        chmod 600 ~/.kaggle/kaggle.json
+        ```
+
+   4. **Verify the Setup**:
+      - Test the Kaggle CLI on the server:
+        ```bash
+        kaggle competitions list
+        ```
+      - If successful, you should see a list of Kaggle competitions.
+
+## Instructions
+
+Follow these steps to download the ImageNet dataset:
+
+1. **Make the script executable**:
+   ```bash
+   chmod +x scripts/download_imagenet.sh
+   ```
+
+2. **Run the script**:
+   ```bash
+   scripts/download_imagenet.sh
+   ```
+
+3. **Data Location**:
+   - The ImageNet dataset will be downloaded and extracted into the `imagenet_data` directory.
+
+4. **Convert Validation Dataset for PyTorch**:
+   - Navigate to the validation data directory:
+     ```bash
+     cd ILSVRC/Data/CLS-LOC/val
+     ```
+   - Run the conversion script (see [here](https://discuss.pytorch.org/t/issues-with-dataloader-for-imagenet-should-i-use-datasets-imagefolder-or-datasets-imagenet/115742/3) for more details):
+     ```bash
+     wget -qO- https://raw.githubusercontent.com/soumith/imagenetloader.torch/master/valprep.sh | bash
+     ```

--- a/docs/download_imagenet.md
+++ b/docs/download_imagenet.md
@@ -21,7 +21,7 @@ Before running the downloading script, ensure the following tools are installed
    ### If Running on a Server:
    Follow these steps to transfer your `kaggle.json` file to the server:
    1. **Locate `kaggle.json` File**:
-      - The `kaggle.json` file is typically downloaded to your local `Downloads` folder after generating an API token.
+      - `kaggle.json` file is typically downloaded to your local `Downloads` folder after generating an API token.
 
    2. **Transfer File to Server**:
       - Use the `scp` command:
@@ -73,7 +73,7 @@ Follow these steps to download the ImageNet dataset:
    ```
 
 4. **Data Location**:
-   - The ImageNet dataset will be downloaded and extracted into the `imagenet_data` directory.
+   - ImageNet dataset will be downloaded and extracted into the `imagenet_data` directory.
 
 5. **Convert Validation Dataset for PyTorch**:
    - Navigate to the validation data directory:

--- a/docs/download_imagenet.md
+++ b/docs/download_imagenet.md
@@ -22,10 +22,10 @@ Before running the downloading script, ensure the following tools are installed
 
    ### If Running on a Server:
    Follow these steps to transfer your `kaggle.json` file to the server:
-   1. **Locate the `kaggle.json` File**:
+   1. **Locate `kaggle.json` File**:
       - The `kaggle.json` file is typically downloaded to your local `Downloads` folder after generating an API token.
 
-   2. **Transfer the File to the Server**:
+   2. **Transfer File to Server**:
       - Use the `scp` command:
         ```bash
         scp ~/Downloads/kaggle.json <username>@<server-ip>:~
@@ -35,7 +35,7 @@ Before running the downloading script, ensure the following tools are installed
         - `<username>` with your server's username.
         - `<server-ip>` with the server's IP address.
 
-   3. **Move the File to the Correct Directory**:
+   3. **Move File to Correct Directory**:
       - Log in to your server:
         ```bash
         ssh <username>@<server-ip>
@@ -50,12 +50,13 @@ Before running the downloading script, ensure the following tools are installed
         chmod 600 ~/.kaggle/kaggle.json
         ```
 
-   4. **Verify the Setup**:
+   4. **Verify Setup**:
       - Test the Kaggle CLI on the server:
         ```bash
         kaggle competitions list
         ```
       - If successful, you should see a list of Kaggle competitions.
+
 
 ## Instructions
 

--- a/docs/download_imagenet.md
+++ b/docs/download_imagenet.md
@@ -4,9 +4,11 @@
 
 Before running the downloading script, ensure the following tools are installed
 
-1. **Kaggle CLI** (install using `pip install kaggle`)
+1. **Navigate to `cuTAGI` folder**
 
-2. **Kaggle API Key**:
+2. **Kaggle CLI** (activate Python environment and install using `pip install kaggle`)
+
+3. **Kaggle API Key**:
    - Go to your [Kaggle Account Settings](https://www.kaggle.com/account).
    - Create and download an API token (`kaggle.json`).
 

--- a/docs/download_imagenet.md
+++ b/docs/download_imagenet.md
@@ -10,7 +10,7 @@ Before running the downloading script, ensure the following tools are installed
    - Go to your [Kaggle Account Settings](https://www.kaggle.com/account).
    - Create and download an API token (`kaggle.json`).
 
-   ### If Running Locally:
+   #### If Running Locally:
    - Save the `kaggle.json` file to the directory `~/.kaggle/`:
      ```bash
      mkdir -p ~/.kaggle
@@ -18,7 +18,7 @@ Before running the downloading script, ensure the following tools are installed
      chmod 600 ~/.kaggle/kaggle.json
      ```
 
-   ### If Running on a Server:
+   #### If Running on a Server:
    Follow these steps to transfer your `kaggle.json` file to the server:
    1. **Locate `kaggle.json` File**:
       - `kaggle.json` file is typically downloaded to your local `Downloads` folder after generating an API token.

--- a/docs/download_imagenet.md
+++ b/docs/download_imagenet.md
@@ -7,7 +7,7 @@ Before running the downloading script, ensure the following tools are installed
 1. **Kaggle CLI** (activate Python environment and install using `pip install kaggle`)
 
 2. **Kaggle API Key**:
-   - Go to your [Kaggle Account Settings](https://www.kaggle.com/account).
+   - Go to your Kaggle Account Settings
    - Create and download an API token (`kaggle.json`).
 
    #### If Running Locally:

--- a/examples/imagenet_resnet_bench.py
+++ b/examples/imagenet_resnet_bench.py
@@ -11,7 +11,6 @@ import numpy as np
 import torch
 import torch.nn as nn
 import torch.optim as optim
-import torchvision
 import torchvision.transforms.v2 as transforms
 from torch.utils.data import DataLoader
 from torchvision import datasets, models, transforms
@@ -19,29 +18,44 @@ from tqdm import tqdm
 
 from examples.tagi_resnet_model import resnet18_imagenet
 from pytagi import HRCSoftmaxMetric, Utils, exponential_scheduler
-from pytagi.nn import (
-    AvgPool2d,
-    BatchNorm2d,
-    Conv2d,
-    Linear,
-    MixtureReLU,
-    OutputUpdater,
-    ReLU,
-    Sequential,
-)
+from pytagi.nn import OutputUpdater
+import pytagi
+
 
 torch.manual_seed(42)
+pytagi.manual_seed(42)
 
 
-def load_datasets(batch_size: int, data_dir: str):
+def custom_collate_fn(batch):
+    # batch is a list of tuples (image, label)
+    batch_images, batch_labels = zip(*batch)
+
+    # Convert to a single tensor
+    batch_images = torch.stack(batch_images)
+    batch_labels = torch.tensor(batch_labels)
+
+    # Flatten images to shape (B*C*H*W,)
+    batch_images = batch_images.reshape(-1)
+
+    # Convert to numpy arrays
+    batch_images = batch_images.numpy()
+    batch_labels = batch_labels.numpy()
+
+    return batch_images, batch_labels
+
+
+def load_datasets(batch_size: int, framework: str = "torch"):
     """Load the ImageNet dataset."""
     # Data Transforms
+    data_dir = "data/imagenet/ILSVRC/Data/CLS-LOC"
+    norm_mean = [0.485, 0.456, 0.406]
+    norm_std = [0.229, 0.224, 0.225]
     train_transforms = transforms.Compose(
         [
             transforms.RandomResizedCrop(224),
             transforms.RandomHorizontalFlip(),
             transforms.ToTensor(),
-            transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
+            transforms.Normalize(mean=norm_mean, std=norm_std),
         ]
     )
 
@@ -50,35 +64,132 @@ def load_datasets(batch_size: int, data_dir: str):
             transforms.Resize(256),
             transforms.CenterCrop(224),
             transforms.ToTensor(),
-            transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
+            transforms.Normalize(mean=norm_mean, std=norm_std),
         ]
     )
 
     # Load datasets
-    train_dataset = datasets.ImageFolder(
-        f"{data_dir}/train", transform=train_transforms
-    )
-    val_dataset = datasets.ImageFolder(f"{data_dir}/val", transform=val_transforms)
+    train_set = datasets.ImageFolder(f"{data_dir}/train", transform=train_transforms)
+    val_set = datasets.ImageFolder(f"{data_dir}/val", transform=val_transforms)
 
-    # Data loaders
-    train_loader = DataLoader(
-        train_dataset, batch_size=batch_size, shuffle=True, num_workers=4
-    )
-    val_loader = DataLoader(
-        val_dataset, batch_size=batch_size, shuffle=False, num_workers=4
-    )
+    if framework == "torch":
+        train_loader = DataLoader(
+            train_set, batch_size=batch_size, shuffle=True, num_workers=4
+        )
+        val_loader = DataLoader(
+            val_set, batch_size=batch_size, shuffle=False, num_workers=4
+        )
+    else:
+        train_loader = DataLoader(
+            train_set,
+            batch_size=batch_size,
+            shuffle=True,
+            num_workers=1,
+            collate_fn=custom_collate_fn,
+        )
+        val_loader = DataLoader(
+            val_set,
+            batch_size=batch_size,
+            shuffle=False,
+            num_workers=1,
+            collate_fn=custom_collate_fn,
+        )
 
     return train_loader, val_loader
 
 
+def tagi_trainer(
+    num_epochs: int,
+    batch_size: int,
+    device: str,
+    sigma_v: float,
+):
+    """
+    Run classification training on the Cifar dataset using a custom neural model.
+
+    Parameters:
+    - num_epochs: int, number of epochs for training
+    - batch_size: int, size of the batch for training
+    """
+    utils = Utils()
+    train_loader, test_loader = load_datasets(batch_size, "tagi")
+
+    # Hierachical Softmax
+    metric = HRCSoftmaxMetric(num_classes=1000)
+
+    # Resnet18
+    net = resnet18_imagenet(gain_w=0.15, gain_b=0.15)
+    device = "cpu" if not pytagi.cuda.is_available() else device
+    net.to_device(device)
+
+    # Training
+    out_updater = OutputUpdater(net.device)
+    var_y = np.full(
+        (batch_size * metric.hrc_softmax.num_obs,), sigma_v**2, dtype=np.float32
+    )
+    with tqdm(range(num_epochs), desc="Epoch Progress") as epoch_pbar:
+        for epoch in epoch_pbar:
+            error_rates = []
+            net.train()
+            with tqdm(
+                train_loader, desc=f"Epoch {epoch + 1}/{num_epochs} - Batch Progress"
+            ) as batch_pbar:
+                for i, (x, labels) in enumerate(batch_pbar):
+                    m_pred, v_pred = net(x)
+
+                    # Update output layers based on targets
+                    y, y_idx, _ = utils.label_to_obs(labels=labels, num_classes=1000)
+                    out_updater.update_using_indices(
+                        output_states=net.output_z_buffer,
+                        mu_obs=y,
+                        var_obs=var_y,
+                        selected_idx=y_idx,
+                        delta_states=net.input_delta_z_buffer,
+                    )
+                    net.backward()
+                    net.step()
+
+                    # Training metric
+                    error_rate = metric.error_rate(m_pred, v_pred, labels)
+                    error_rates.append(error_rate)
+
+                    if i > 0 and i % 100 == 0:
+                        avg_error_rate = sum(error_rates[-100:])
+                        batch_pbar.set_description(
+                            f"Training error: {avg_error_rate:.2f}%",
+                            refresh=True,
+                        )
+
+            # Averaged training error
+            avg_error_rate = sum(error_rates[-100:])
+
+            # Testing
+            test_error_rates = []
+            net.eval()
+            for x, labels in test_loader:
+                m_pred, v_pred = net(x)
+
+                # Training metric
+                error_rate = metric.error_rate(m_pred, v_pred, labels)
+                test_error_rates.append(error_rate)
+
+            test_error_rate = sum(test_error_rates) / len(test_error_rates)
+            epoch_pbar.set_description(
+                f"Epoch {epoch + 1}/{num_epochs} | training error: {avg_error_rate:.2f}% | test error: {test_error_rate * 100:.2f}\n%",
+                refresh=True,
+            )
+    print("Training complete.")
+
+
 def torch_trainer(batch_size: int, num_epochs: int, device: str = "cuda"):
     """Train ResNet-18 on the ImageNet dataset."""
+    # torch.set_float32_matmul_precision("high")
+
     # Hyperparameters
     learning_rate = 0.001
-    data_dir = "data/imagenet/ILSVRC/Data/CLS-LOC"
 
     # Load ImageNet datasets
-    train_loader, val_loader = load_datasets(batch_size, data_dir)
+    train_loader, val_loader = load_datasets(batch_size, "torch")
 
     # Initialize the model
     torch_device = torch.device(device)
@@ -96,67 +207,76 @@ def torch_trainer(batch_size: int, num_epochs: int, device: str = "cuda"):
     optimizer = optim.Adam(model.parameters(), lr=learning_rate)
 
     # Training loop
-    pbar = tqdm(range(num_epochs), desc="Training Progress")
-    for epoch in pbar:
-        model.train()
-        error_rates = []
+    with tqdm(range(num_epochs), desc="Epoch Progress") as epoch_pbar:
+        for epoch in epoch_pbar:
+            model.train()
+            error_rates = []
 
-        # Training phase
-        for _, (data, target) in enumerate(train_loader):
-            data = data.to(torch_device)
-            target = target.to(torch_device)
+            with tqdm(
+                train_loader, desc=f"Epoch {epoch + 1}/{num_epochs} - Batch Progress"
+            ) as batch_pbar:
+                for i, (data, target) in enumerate(batch_pbar):
+                    data = data.to(torch_device)
+                    target = target.to(torch_device)
 
-            optimizer.zero_grad()
-            output = model(data)
-            loss = criterion(output, target)
+                    optimizer.zero_grad()
+                    output = model(data)
+                    loss = criterion(output, target)
 
-            loss.backward()
-            optimizer.step()
+                    loss.backward()
+                    optimizer.step()
 
-            pred = output.argmax(dim=1, keepdim=True)
-            train_correct = pred.eq(target.view_as(pred)).sum().item()
-            error_rates.append((1.0 - (train_correct / data.shape[0])))
+                    pred = output.argmax(dim=1, keepdim=True)
+                    train_correct = pred.eq(target.view_as(pred)).sum().item()
+                    error_rates.append((1.0 - (train_correct / data.shape[0])))
 
-        # Averaged error
-        avg_error_rate = sum(error_rates[-100:])
+                    if i > 0 and i % 100 == 0:
+                        avg_error_rate = sum(error_rates[-100:])
+                        batch_pbar.set_description(
+                            f"Training error: {avg_error_rate:.2f}%",
+                            refresh=True,
+                        )
 
-        # Evaluation phase
-        model.eval()
-        val_loss = 0
-        correct = 0
-        with torch.no_grad():
-            for data, target in val_loader:
-                data = data.to(torch_device)
-                target = target.to(torch_device)
-                output = model(data)
+            # Averaged training error
+            avg_error_rate = sum(error_rates[-100:])
 
-                val_loss += criterion(output, target).item()
-                pred = output.argmax(dim=1, keepdim=True)
-                correct += pred.eq(target.view_as(pred)).sum().item()
+            # Evaluation phase
+            model.eval()
+            val_loss = 0
+            correct = 0
+            with torch.no_grad():
+                for data, target in val_loader:
+                    data = data.to(torch_device)
+                    target = target.to(torch_device)
+                    output = model(data)
 
-        val_loss /= len(val_loader.dataset)
-        val_error_rate = (1.0 - correct / len(val_loader.dataset)) * 100
-        pbar.set_description(
-            f"Epoch# {epoch + 1}/{num_epochs} | Training Error: {avg_error_rate:.2f}% | Validation Error: {val_error_rate:.2f}%\n",
-            refresh=False,
-        )
+                    val_loss += criterion(output, target).item()
+                    pred = output.argmax(dim=1, keepdim=True)
+                    correct += pred.eq(target.view_as(pred)).sum().item()
+
+            val_loss /= len(val_loader.dataset)
+            val_error_rate = (1.0 - correct / len(val_loader.dataset)) * 100
+            epoch_pbar.set_description(
+                f"Epoch# {epoch + 1}/{num_epochs} | Training Error: {avg_error_rate:.2f}% | Validation Error: {val_error_rate:.2f}%",
+                refresh=True,
+            )
 
     print("Training complete!")
 
 
 def main(
-    framework: str = "torch",
+    framework: str = "tagi",
     batch_size: int = 64,
-    epochs: int = 50,
+    epochs: int = 1,
     device: str = "cuda",
     sigma_v: float = 0.1,
 ):
     if framework == "torch":
         torch_trainer(batch_size=batch_size, num_epochs=epochs, device=device)
-    # elif framework == "tagi":
-    #     tagi_trainer(
-    #         batch_size=batch_size, num_epochs=epochs, device=device, sigma_v=sigma_v
-    #     )
+    elif framework == "tagi":
+        tagi_trainer(
+            batch_size=batch_size, num_epochs=epochs, device=device, sigma_v=sigma_v
+        )
     else:
         raise RuntimeError(f"Invalid Framework: {framework}")
 

--- a/examples/imagenet_resnet_bench.py
+++ b/examples/imagenet_resnet_bench.py
@@ -1,0 +1,165 @@
+# Temporary import. It will be removed in the final vserion
+import os
+import sys
+
+# Add the 'build' directory to sys.path in one line
+sys.path.append(
+    os.path.normpath(os.path.join(os.path.dirname(__file__), "..", "build"))
+)
+import fire
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.optim as optim
+import torchvision
+import torchvision.transforms.v2 as transforms
+from torch.utils.data import DataLoader
+from torchvision import datasets, models, transforms
+from tqdm import tqdm
+
+from examples.tagi_resnet_model import resnet18_imagenet
+from pytagi import HRCSoftmaxMetric, Utils, exponential_scheduler
+from pytagi.nn import (
+    AvgPool2d,
+    BatchNorm2d,
+    Conv2d,
+    Linear,
+    MixtureReLU,
+    OutputUpdater,
+    ReLU,
+    Sequential,
+)
+
+torch.manual_seed(42)
+
+
+def load_datasets(batch_size: int, data_dir: str = "data/imagenet"):
+    """Load the ImageNet dataset."""
+    # Data Transforms
+    train_transforms = transforms.Compose(
+        [
+            transforms.RandomResizedCrop(224),
+            transforms.RandomHorizontalFlip(),
+            transforms.ToTensor(),
+            transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
+        ]
+    )
+
+    val_transforms = transforms.Compose(
+        [
+            transforms.Resize(256),
+            transforms.CenterCrop(224),
+            transforms.ToTensor(),
+            transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
+        ]
+    )
+
+    # Load datasets
+    train_dataset = datasets.ImageFolder(
+        f"{data_dir}/train", transform=train_transforms
+    )
+    val_dataset = datasets.ImageFolder(f"{data_dir}/val", transform=val_transforms)
+
+    # Data loaders
+    train_loader = DataLoader(
+        train_dataset, batch_size=batch_size, shuffle=True, num_workers=4
+    )
+    val_loader = DataLoader(
+        val_dataset, batch_size=batch_size, shuffle=False, num_workers=4
+    )
+
+    return train_loader, val_loader
+
+
+def torch_trainer(batch_size: int, num_epochs: int, device: str = "cuda"):
+    """Train ResNet-18 on the ImageNet dataset."""
+    # Hyperparameters
+    learning_rate = 0.001
+    data_dir = "data/imagenet/ILSVRC/Data/CLS-LOC"
+
+    # Load ImageNet datasets
+    train_loader, val_loader = load_datasets(batch_size, data_dir)
+
+    # Initialize the model
+    torch_device = torch.device(device)
+    if "cuda" in device and not torch.cuda.is_available():
+        raise RuntimeError(
+            "CUDA is not available. Please check your CUDA installation."
+        )
+    model = models.resnet18(pretrained=True)
+    num_ftrs = model.fc.in_features
+    model.fc = nn.Linear(num_ftrs, len(train_loader.dataset.classes))
+    model.to(torch_device)
+
+    # Define loss function and optimizer
+    criterion = nn.CrossEntropyLoss()
+    optimizer = optim.Adam(model.parameters(), lr=learning_rate)
+
+    # Training loop
+    pbar = tqdm(range(num_epochs), desc="Training Progress")
+    for epoch in pbar:
+        model.train()
+        error_rates = []
+
+        # Training phase
+        for _, (data, target) in enumerate(train_loader):
+            data = data.to(torch_device)
+            target = target.to(torch_device)
+
+            optimizer.zero_grad()
+            output = model(data)
+            loss = criterion(output, target)
+
+            loss.backward()
+            optimizer.step()
+
+            pred = output.argmax(dim=1, keepdim=True)
+            train_correct = pred.eq(target.view_as(pred)).sum().item()
+            error_rates.append((1.0 - (train_correct / data.shape[0])))
+
+        # Averaged error
+        avg_error_rate = sum(error_rates[-100:])
+
+        # Evaluation phase
+        model.eval()
+        val_loss = 0
+        correct = 0
+        with torch.no_grad():
+            for data, target in val_loader:
+                data = data.to(torch_device)
+                target = target.to(torch_device)
+                output = model(data)
+
+                val_loss += criterion(output, target).item()
+                pred = output.argmax(dim=1, keepdim=True)
+                correct += pred.eq(target.view_as(pred)).sum().item()
+
+        val_loss /= len(val_loader.dataset)
+        val_error_rate = (1.0 - correct / len(val_loader.dataset)) * 100
+        pbar.set_description(
+            f"Epoch# {epoch + 1}/{num_epochs} | Training Error: {avg_error_rate:.2f}% | Validation Error: {val_error_rate:.2f}%\n",
+            refresh=False,
+        )
+
+    print("Training complete!")
+
+
+def main(
+    framework: str = "torch",
+    batch_size: int = 64,
+    epochs: int = 50,
+    device: str = "cuda",
+    sigma_v: float = 0.1,
+):
+    if framework == "torch":
+        torch_trainer(batch_size=batch_size, num_epochs=epochs, device=device)
+    # elif framework == "tagi":
+    #     tagi_trainer(
+    #         batch_size=batch_size, num_epochs=epochs, device=device, sigma_v=sigma_v
+    #     )
+    else:
+        raise RuntimeError(f"Invalid Framework: {framework}")
+
+
+if __name__ == "__main__":
+    fire.Fire(main)

--- a/examples/imagenet_resnet_bench.py
+++ b/examples/imagenet_resnet_bench.py
@@ -33,7 +33,7 @@ from pytagi.nn import (
 torch.manual_seed(42)
 
 
-def load_datasets(batch_size: int, data_dir: str = "data/imagenet"):
+def load_datasets(batch_size: int, data_dir: str):
     """Load the ImageNet dataset."""
     # Data Transforms
     train_transforms = transforms.Compose(

--- a/examples/tagi_resnet_model.py
+++ b/examples/tagi_resnet_model.py
@@ -7,6 +7,7 @@ from pytagi.nn import (
     MixtureReLU,
     ResNetBlock,
     Sequential,
+    ReLU,
 )
 
 
@@ -125,5 +126,90 @@ def resnet18_cifar10(gain_w: float = 1, gain_b: float = 1) -> Sequential:
     ]
 
     final_layers = [AvgPool2d(4), Linear(512, 11, gain_weight=gain_b, gain_bias=gain_b)]
+
+    return Sequential(*initial_layers, *resnet_layers, *final_layers)
+
+
+def resnet18_imagenet(gain_w: float = 1, gain_b: float = 1) -> Sequential:
+    """Resnet18 architecture for imagenet"""
+    # 224x224
+    initial_layers = [
+        Conv2d(
+            3,
+            64,
+            6,
+            bias=False,
+            padding=2,
+            in_width=224,
+            in_height=224,
+            gain_weight=gain_w,
+            gain_bias=gain_b,
+        ),
+        MixtureReLU(),
+        BatchNorm2d(64),
+        AvgPool2d(3, stride=2, padding=1, padding_type=2),
+    ]
+
+    resnet_layers = [
+        # 56x56
+        ResNetBlock(make_layer_block(64, 64, gain_weight=gain_w, gain_bias=gain_b)),
+        ResNetBlock(make_layer_block(64, 64, gain_weight=gain_w, gain_bias=gain_b)),
+        # 28x28
+        ResNetBlock(
+            make_layer_block(64, 128, 2, 2, gain_weight=gain_w, gain_bias=gain_b),
+            LayerBlock(
+                Conv2d(
+                    64,
+                    128,
+                    2,
+                    bias=False,
+                    stride=2,
+                    gain_weight=gain_w,
+                    gain_bias=gain_b,
+                ),
+                BatchNorm2d(128),
+            ),
+        ),
+        ResNetBlock(make_layer_block(128, 128, gain_weight=gain_w, gain_bias=gain_b)),
+        # 14x14
+        ResNetBlock(
+            make_layer_block(128, 256, 2, 2, gain_weight=gain_w, gain_bias=gain_b),
+            LayerBlock(
+                Conv2d(
+                    128,
+                    256,
+                    2,
+                    bias=False,
+                    stride=2,
+                    gain_weight=gain_w,
+                    gain_bias=gain_b,
+                ),
+                BatchNorm2d(256),
+            ),
+        ),
+        ResNetBlock(make_layer_block(256, 256, gain_weight=gain_w, gain_bias=gain_b)),
+        # 7x7
+        ResNetBlock(
+            make_layer_block(256, 512, 2, 2, gain_weight=gain_w, gain_bias=gain_b),
+            LayerBlock(
+                Conv2d(
+                    256,
+                    512,
+                    2,
+                    bias=False,
+                    stride=2,
+                    gain_weight=gain_w,
+                    gain_bias=gain_b,
+                ),
+                BatchNorm2d(512),
+            ),
+        ),
+        ResNetBlock(make_layer_block(512, 512, gain_weight=gain_w, gain_bias=gain_b)),
+    ]
+
+    final_layers = [
+        AvgPool2d(7),
+        Linear(512, 1001, gain_weight=gain_b, gain_bias=gain_b),
+    ]
 
     return Sequential(*initial_layers, *resnet_layers, *final_layers)

--- a/examples/tagi_resnet_model.py
+++ b/examples/tagi_resnet_model.py
@@ -140,6 +140,7 @@ def resnet18_imagenet(gain_w: float = 1, gain_b: float = 1) -> Sequential:
             6,
             bias=False,
             padding=2,
+            stride=2,
             in_width=224,
             in_height=224,
             gain_weight=gain_w,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires=[
     "setuptools>=42",
     "wheel>=0.44.0",
     "cmake>=3.22",
-    "ninja>=1.11.1.1",
+    "ninja>=1.11.1.2",
     "numpy>=1.26.0"
 ]
 build-backend = "setuptools.build_meta"

--- a/pytagi/nn/data_struct.py
+++ b/pytagi/nn/data_struct.py
@@ -113,7 +113,7 @@ class HRCSoftmax:
     Attributes:
         obs: A fictive observation \in [-1, 1]
         idx: Indices assigned to each label
-        n_obs: Number of indices for each label
+        num_obs: Number of indices for each label
         len: Length of an observation e.g 10 labels -> len(obs) = 11
     """
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-matplotlib==3.8.2
-ninja==1.11.1.1
-numpy==1.26.0
-pandas==2.1.4
-tqdm==4.66.1
-fire==0.5.0
+matplotlib~=3.9.2
+ninja~=1.11.1.2
+numpy~=1.26.0
+pandas~=2.2.3
+tqdm~=4.66.1
+fire~=0.5.0

--- a/scripts/download_imagenet.sh
+++ b/scripts/download_imagenet.sh
@@ -12,6 +12,7 @@ kaggle competitions download -c imagenet-object-localization-challenge
 # Unzip the downloaded files
 echo "Extracting downloaded files..."
 unzip '*.zip'
+
 # Remove the zip files after extraction
 echo "Removing zip files..."
 rm *.zip

--- a/scripts/download_imagenet.sh
+++ b/scripts/download_imagenet.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+DOWNLOAD_DIR="data/imagenet"
+
+mkdir -p $DOWNLOAD_DIR
+
+cd $DOWNLOAD_DIR
+
+echo "Downloading ImageNet data from Kaggle..."
+kaggle competitions download -c imagenet-object-localization-challenge
+
+# Unzip the downloaded files
+echo "Extracting downloaded files..."
+unzip '*.zip'
+# Remove the zip files after extraction
+echo "Removing zip files..."
+rm *.zip
+
+echo "Download and extraction complete!"
+

--- a/src/conv2d_layer.cpp
+++ b/src/conv2d_layer.cpp
@@ -614,7 +614,12 @@ std::tuple<int, int> compute_downsample_img_size_v2(int kernel, int stride,
         wo = nom_w / stride + 1;
         ho = nom_h / stride + 1;
     } else {
-        LOG(LogLevel::ERROR, "Invalid hyperparameters for conv2d layer");
+        LOG(LogLevel::ERROR,
+            "Invalid hyperparameters for conv2d layer: "
+            "wi=" +
+                std::to_string(wi) + ", hi=" + std::to_string(hi) +
+                ", kernel=" + std::to_string(kernel) +
+                ", stride=" + std::to_string(stride));
     }
 
     return {wo, ho};

--- a/src/cost.cpp
+++ b/src/cost.cpp
@@ -132,7 +132,7 @@ HRCSoftmax class_to_obs(int n_classes)
         }
     }
 
-    // Compute the lenght of the observation vector
+    // Compute the length of the observation vector
     int len = *std::max_element(idx.begin(), idx.end());
 
     return {obs, idx, L, len};


### PR DESCRIPTION
## Description

This PR added Python training script for imagenet using resnet18 architecture. It also added the download script and its instructions

## Changes Made

- Added download scripts `scripts/download_imagenet.sh`
- Added training script for imagenet `examples/imagenet_resnet_bench.py` similar to cifar resnet bench
- Added doc for the use of imagenet download scripts `docs/download_imagenet.md`

## Checklist

- [x]  I have followed the project's coding conventions and style guidelines.
- [x]  I have updated the documentation, if applicable.
- [x]  I have rebased my branch on the latest upstream code to incorporate any changes.
- [x]  I have tested the changes locally.


## Notes for Reviewers

- See `docs/download_imagenet.md` to download the imagenet through kaggle
- It will take ~1hour (800 Mbps internet connection) for downloading the imagetnet dataset depending on your internet connection 
- Ensure you have ~300GB available for zip file and its extracted file. Zip file will be removed after the the extraction
- Here is the command to run the imagenet training using either tagi or torch
  ```bash
  python -m examples.imagenet_resnet_bench tagi
  ```
  ```bash
  python -m examples.imagenet_resnet_bench torch
  ```