### PR TITLE
Feature/orthogonal initialization

### DIFF
--- a/include/param_init.h
+++ b/include/param_init.h
@@ -1,7 +1,12 @@
 
 #pragma once
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <eigen3/Eigen/Dense>
 #include <iomanip>
 #include <iostream>
+#include <numeric>
 #include <random>
 #include <string>
 #include <tuple>


### PR DESCRIPTION
## Description

This PR added orthogonal initialization for Linear, Convolutional and LSTM layers.

## Changes Made

- Added orthogonal init function in `src/param_init.cpp`.
- Modified initialization of Linear, CNN and LSTM layers to accept orthogonal init in `src/param_init.cpp`.
- Added `#include <eigen3/Eigen/Dense>` in `include/param_init.h`.

## Checklist

- [x]  I have followed the project's coding conventions and style guidelines.
- [x]  I have updated the documentation, if applicable.
- [x] I have rebased my branch on the latest upstream code to incorporate any changes.
- [x] I have tested the changes locally.


## Notes for Reviewers

I use the external library Eigen to perform SVD efficiently on C++. Hence it is necessary to install the library running:
```
sudo apt install libeigen3-dev
```
or manually installing the library from [Eigen](https://eigen.tuxfamily.org/index.php?title=Main_Page).
