### PR TITLE
Add reset_lstm_states function to sequential class

### DIFF
--- a/examples/time_series_forecasting.py
+++ b/examples/time_series_forecasting.py
@@ -61,7 +61,7 @@ def main(num_epochs: int = 50, batch_size: int = 5, sigma_v: float = 1):
         LSTM(8, 8, input_seq_len),
         Linear(8 * input_seq_len, 1),
     )
-    net.to_device("cuda")
+    # net.to_device("cuda")
     net.set_threads(1)  # multi-processing is slow on a small net
     # net.input_state_update = True
     out_updater = OutputUpdater(net.device)
@@ -105,6 +105,7 @@ def main(num_epochs: int = 50, batch_size: int = 5, sigma_v: float = 1):
             mse = metric.mse(pred, obs)
             mses.append(mse)
 
+        net.reset_lstm_states()
         # Progress bar
         pbar.set_description(
             f"Epoch {epoch + 1}/{num_epochs}| mse: {sum(mses)/len(mses):>7.2f}",

--- a/include/sequential.h
+++ b/include/sequential.h
@@ -104,6 +104,8 @@ class Sequential {
 
     void step();
 
+    void reset_lstm_states();
+
     // DEBUG
     void output_to_host();
     void delta_z_to_host();

--- a/pytagi/nn/sequential.py
+++ b/pytagi/nn/sequential.py
@@ -155,6 +155,10 @@ class Sequential:
         """Perform a step of inference."""
         self._cpp_backend.step()
 
+    def reset_lstm_states(self):
+        """Reset lstm states"""
+        self._cpp_backend.reset_lstm_states()
+
     def output_to_host(self) -> List[float]:
         """Copy the output data to the host."""
         return self._cpp_backend.output_to_host()

--- a/src/bindings/sequential_bindings.cpp
+++ b/src/bindings/sequential_bindings.cpp
@@ -68,6 +68,7 @@ void bind_sequential(pybind11::module_& m) {
         .def("backward", &Sequential::backward)
         .def("smoother", &Sequential::smoother)
         .def("step", &Sequential::step)
+        .def("reset_lstm_states", &Sequential::reset_lstm_states)
         .def("output_to_host", &Sequential::output_to_host)
         .def("delta_z_to_host", &Sequential::delta_z_to_host)
         .def("get_layer_stack_info", &Sequential::get_layer_stack_info)

--- a/src/sequential.cpp
+++ b/src/sequential.cpp
@@ -391,6 +391,21 @@ void Sequential::step()
     }
 }
 
+void Sequential::reset_lstm_states()
+/*
+ */
+{
+    // Hidden layers
+    for (auto layer = this->layers.begin(); layer != this->layers.end();
+         layer++) {
+        auto *current_layer = layer->get();
+        if (current_layer->get_layer_type() == LayerType::LSTM) {
+            auto *lstm_layer = dynamic_cast<LSTM *>(current_layer);
+            lstm_layer->lstm_states.reset_zeros();
+        }
+    }
+}
+
 void Sequential::output_to_host() {
 #ifdef USE_CUDA
     if (this->device.compare("cuda") == 0) {


### PR DESCRIPTION
## Description

This PR adds the `reset_lstm_states` functions to `sequential` class in both c++ and python. This function resets all LSTM variables including previous cell, hidden states, gates when being called. Typically, this function is called at the end of each epoch, so that all LSTM's variables are clear before moving to the next epoch.

## Changes Made

- Add `reset_lstm_states` functions to `sequential.cpp` and  `sequential.py`
- Use this function in `time_series_forecasting.py`

## Notes for Reviewers

- Run `python -m examples.time_series_forecasting`