### PR TITLE
Feature/neg var count stat

### DIFF
--- a/examples/classification.py
+++ b/examples/classification.py
@@ -117,7 +117,7 @@ def main(num_epochs: int = 10, batch_size: int = 128, sigma_v: float = 0.1):
     metric = HRCSoftmaxMetric(num_classes=10)
 
     # Network configuration
-    net = CNN_BATCHNORM
+    net = CNN
     if pytagi.cuda.is_available():
         net.to_device("cuda")
     else:

--- a/include/base_layer.h
+++ b/include/base_layer.h
@@ -42,6 +42,7 @@ class BaseLayer {
     bool bias = true;
     bool param_update = true;
     float cap_factor_update = 1.0f;
+    int neg_var_w_counter = 0;
 
     std::vector<float> mu_w;
     std::vector<float> var_w;
@@ -132,8 +133,8 @@ class BaseLayer {
     // DEBUG
     virtual std::tuple<std::vector<float>, std::vector<float>>
     get_running_mean_var();
-
     virtual void preinit_layer();
+    int get_neg_var_w_counter();
 
    protected:
     void allocate_bwd_vector(int size);

--- a/include/base_layer_cuda.cuh
+++ b/include/base_layer_cuda.cuh
@@ -22,6 +22,7 @@ class BaseLayerCuda : public BaseLayer {
     float *d_delta_var_w = nullptr;
     float *d_delta_mu_b = nullptr;
     float *d_delta_var_b = nullptr;
+    int *d_negative_var_count = nullptr;
     unsigned int num_cuda_threads = 16;
 
     BaseLayerCuda();

--- a/include/base_layer_cuda.cuh
+++ b/include/base_layer_cuda.cuh
@@ -22,7 +22,7 @@ class BaseLayerCuda : public BaseLayer {
     float *d_delta_var_w = nullptr;
     float *d_delta_mu_b = nullptr;
     float *d_delta_var_b = nullptr;
-    int *d_negative_var_count = nullptr;
+    int *d_neg_var_count = nullptr;
     unsigned int num_cuda_threads = 16;
 
     BaseLayerCuda();

--- a/include/sequential.h
+++ b/include/sequential.h
@@ -110,6 +110,7 @@ class Sequential {
     void output_to_host();
     void delta_z_to_host();
     void preinit_layer();
+    int get_neg_var_w_counter();
 
     // Utility function to get layer stack info
     std::string get_layer_stack_info() const;

--- a/include/sequential.h
+++ b/include/sequential.h
@@ -23,6 +23,7 @@
 #include <pybind11/stl.h>
 
 #include <map>
+#include <unordered_map>
 
 class Sequential {
    public:
@@ -110,7 +111,7 @@ class Sequential {
     void output_to_host();
     void delta_z_to_host();
     void preinit_layer();
-    int get_neg_var_w_counter();
+    std::unordered_map<std::string, int> get_neg_var_w_counter();
 
     // Utility function to get layer stack info
     std::string get_layer_stack_info() const;

--- a/pytagi/nn/sequential.py
+++ b/pytagi/nn/sequential.py
@@ -175,7 +175,7 @@ class Sequential:
         """Preinitialize the layer."""
         self._cpp_backend.preinit_layer()
 
-    def get_neg_var_w_counter(self) -> int:
+    def get_neg_var_w_counter(self) -> dict:
         """Get the number of negative variance weights."""
         return self._cpp_backend.get_neg_var_w_counter()
 

--- a/pytagi/nn/sequential.py
+++ b/pytagi/nn/sequential.py
@@ -175,6 +175,10 @@ class Sequential:
         """Preinitialize the layer."""
         self._cpp_backend.preinit_layer()
 
+    def get_neg_var_w_counter(self) -> int:
+        """Get the number of negative variance weights."""
+        return self._cpp_backend.get_neg_var_w_counter()
+
     def save(self, filename: str):
         """Save the model to a file."""
         self._cpp_backend.save(filename)

--- a/src/base_layer.cpp
+++ b/src/base_layer.cpp
@@ -103,7 +103,6 @@ void BaseLayer::raw_update_weights()
 
 void BaseLayer::raw_update_biases()
 /*
-
  */
 {
     if (this->bias) {
@@ -118,6 +117,7 @@ void BaseLayer::update_weights()
 /*
  */
 {
+    this->neg_var_w_counter = 0;
     for (int i = 0; i < this->mu_w.size(); i++) {
         float delta_mu_sign =
             (this->delta_mu_w[i] > 0) - (this->delta_mu_w[i] < 0);
@@ -131,6 +131,7 @@ void BaseLayer::update_weights()
             delta_var_sign * std::min(std::abs(delta_var_w[i]), delta_bar);
         if (var_w[i] <= 0.0f) {
             var_w[i] = 1E-5f;  // TODO: replace by a parameter
+            this->neg_var_w_counter++;
         }
     }
 }
@@ -309,3 +310,5 @@ void BaseLayer::preinit_layer()
 {
     // We do nothing by default
 }
+
+int BaseLayer::get_neg_var_w_counter() { return this->neg_var_w_counter; }

--- a/src/base_layer_cuda.cu
+++ b/src/base_layer_cuda.cu
@@ -56,7 +56,8 @@ __global__ void device_raw_bias_update(float const *delta_mu_b,
 __global__ void device_weight_update(float const *delta_mu_w,
                                      float const *delta_var_w,
                                      float cap_factor_udapte, size_t size,
-                                     float *mu_w, float *var_w)
+                                     float *mu_w, float *var_w,
+                                     int *negative_var_count)
 /*
  */
 {
@@ -73,7 +74,7 @@ __global__ void device_weight_update(float const *delta_mu_w,
         var_w[col] += delta_var_sign * min(sqrt(tmp_var * tmp_var), delta_bar);
         if (var_w[col] <= 0.0f) {
             var_w[col] = 1E-5f;
-            // printf("w"); //Constrain printout for debugging
+            atomicAdd(negative_var_count, 1);
         }
     }
 }
@@ -120,6 +121,7 @@ BaseLayerCuda::~BaseLayerCuda()
     cudaFree(d_delta_var_w);
     cudaFree(d_delta_mu_b);
     cudaFree(d_delta_var_b);
+    cudaFree(d_negative_var_count);
 }
 
 void BaseLayerCuda::allocate_param_delta()
@@ -184,14 +186,33 @@ void BaseLayerCuda::update_weights()
 /*
  */
 {
-    // TODO: replace with capped update version
     unsigned int num_add_threads = 256;
     unsigned int blocks =
         (this->num_weights + num_add_threads - 1) / num_add_threads;
 
+    // Reset counter - using synchronous copy since we need it complete before
+    // kernel launch
+    this->neg_var_w_counter = 0;
+    cudaError_t err =
+        cudaMemcpy(this->d_negative_var_count, &this->neg_var_w_counter,
+                   sizeof(int), cudaMemcpyHostToDevice);
+    if (err != cudaSuccess) {
+        throw std::runtime_error("Failed to copy negative var count to device");
+    }
+
     device_weight_update<<<blocks, num_add_threads>>>(
         this->d_delta_mu_w, this->d_delta_var_w, this->cap_factor_update,
-        this->num_weights, this->d_mu_w, this->d_var_w);
+        this->num_weights, this->d_mu_w, this->d_var_w,
+        this->d_negative_var_count);
+
+    // Get the count back - using synchronous copy since we need the value
+    // immediately
+    err = cudaMemcpy(&this->neg_var_w_counter, this->d_negative_var_count,
+                     sizeof(int), cudaMemcpyDeviceToHost);
+    if (err != cudaSuccess) {
+        throw std::runtime_error(
+            "Failed to copy negative var count from device");
+    }
 }
 
 void BaseLayerCuda::update_biases()

--- a/src/bindings/sequential_bindings.cpp
+++ b/src/bindings/sequential_bindings.cpp
@@ -73,6 +73,7 @@ void bind_sequential(pybind11::module_& m) {
         .def("delta_z_to_host", &Sequential::delta_z_to_host)
         .def("get_layer_stack_info", &Sequential::get_layer_stack_info)
         .def("preinit_layer", &Sequential::preinit_layer)
+        .def("get_neg_var_w_counter", &Sequential::get_neg_var_w_counter)
         .def("save", &Sequential::save)
         .def("load", &Sequential::load)
         .def("save_csv", &Sequential::save_csv)

--- a/src/sequential.cpp
+++ b/src/sequential.cpp
@@ -430,6 +430,14 @@ void Sequential::delta_z_to_host() {
 #endif
 }
 
+int Sequential::get_neg_var_w_counter() {
+    int count = 0;
+    for (const auto &layer : this->layers) {
+        count += layer->get_neg_var_w_counter();
+    }
+    return count;
+}
+
 // Utility function to get layer stack info
 std::string Sequential::get_layer_stack_info() const {
     std::stringstream ss;

--- a/src/sequential.cpp
+++ b/src/sequential.cpp
@@ -430,12 +430,12 @@ void Sequential::delta_z_to_host() {
 #endif
 }
 
-int Sequential::get_neg_var_w_counter() {
-    int count = 0;
+std::unordered_map<std::string, int> Sequential::get_neg_var_w_counter() {
+    std::unordered_map<std::string, int> counter;
     for (const auto &layer : this->layers) {
-        count += layer->get_neg_var_w_counter();
+        counter[layer->get_layer_info()] = layer->get_neg_var_w_counter();
     }
-    return count;
+    return counter;
 }
 
 // Utility function to get layer stack info


### PR DESCRIPTION
## Description

This PR added the debugging tool that counts the number of updates that has a negative variance for each layer.

## Changes Made

- Added the counter for negative variance of weights to base layer in both cuda and cpu
- Added python API for retrieving the counter for each layer where the output is a dictionary with the key is the name of layer and value is the cumulative sum of the negative variance

## Checklist

- [x]  I have followed the project's coding conventions and style guidelines.
- [x]  I have updated the documentation, if applicable.
- [x]  I have rebased my branch on the latest upstream code to incorporate any changes.
- [x]  I have tested the changes locally.


## Notes for Reviewers

Add `print(net.get_neg_var_w_counter())` right after `net.step()`. It will printout the counter for the negative variances for each layer.