### PR TITLE
Hotfix/windows cpu compilation

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -253,4 +253,3 @@ jobs:
         run: |
           twine upload --skip-existing dist/*
 # twine upload --repository-url https://test.pypi.org/legacy/ --skip-existing dist/*
-    

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -106,6 +106,48 @@ jobs:
           name: macos-wheels-${{ matrix.python_version }}
           path: ./wheelhouse/*.whl
 
+  build_windows:
+    name: Windows Build (CPU Only)
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        include:
+          - python_version: "3.10"
+            cibw_build: "cp310-win_amd64"
+          - python_version: "3.11"
+            cibw_build: "cp311-win_amd64"
+          - python_version: "3.12"
+            cibw_build: "cp312-win_amd64"
+    if: ${{ github.event.pull_request.draft == false }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up Python ${{ matrix.python_version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python_version }}
+
+      - name: Install cibuildwheel and NumPy <2.0
+        run: |
+          python -m pip install cibuildwheel==2.21.3
+          python -m pip install "numpy<2.0"
+
+      - name: Build wheels (CPU Only)
+        run: |
+          python -m cibuildwheel --output-dir wheelhouse
+        env:
+          CIBW_BUILD: ${{ matrix.cibw_build }}
+          CIBW_ARCHS_WINDOWS: auto64
+          CIBW_BUILD_VERBOSITY: 1
+          CIBW_ENVIRONMENT: "FORCE_CPU_ONLY=1 CMAKE_ARGS='-DBUILD_TESTING=OFF'"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: windows-wheels-cpu-${{ matrix.python_version }}
+          path: ./wheelhouse/*.whl
+
   build_sdist:
     name: SDist Build
     runs-on: ${{ matrix.os }}
@@ -140,7 +182,7 @@ jobs:
 
   test:
     name: Test
-    needs: [build_linux, build_macos, build_sdist]
+    needs: [build_linux, build_macos, build_windows, build_sdist]
     runs-on: ubuntu-22.04
     if: ${{ github.event.pull_request.draft == false }}
     steps:
@@ -193,11 +235,11 @@ jobs:
         with:
           path: ./artifacts
 
-      - name: Collect all build files
+      - name: Collect and clean all build files
         run: |
           mkdir dist
           find ./artifacts -type f \( -name "*.whl" -o -name "*.tar.gz" \) -exec cp {} dist/ \;
-
+          rm -rf build *.egg-info  # Clean any stale metadata
 
       - name: Install twine
         run: |
@@ -211,3 +253,4 @@ jobs:
         run: |
           twine upload --skip-existing dist/*
 # twine upload --repository-url https://test.pypi.org/legacy/ --skip-existing dist/*
+    

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,6 @@ PROJECT(
   LANGUAGES CXX
 )
 set(CUTAGI_VERSION "${CMAKE_PROJECT_VERSION}")
-
 # ##############################################################################
 # # C++ COMPILER SETUP
 # ##############################################################################
@@ -22,34 +21,28 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
   set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "RelWithDebInfo")
 endif()
-
 if(MSVC)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /D_CRT_SECURE_NO_WARNINGS")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP24")
 else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpic")
 endif()
-
 find_package(Threads REQUIRED)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
-
 set(CMAKE_CXX_STANDARD 14) # C++ version
 set(CMAKE_CXX_EXTENSIONS OFF) # Disable GNU extenstions
-
 if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
   set(BUILD_SHARED_LIBS ON)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -flto=auto")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -flto=auto")
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -flto=auto")
 endif()
-
 # ##############################################################################
 # # CUDA COMPILER SETUP
 # ##############################################################################
 # Check CUDA availability
 include(CheckLanguage)
 check_language(CUDA)
-
 if(CMAKE_CUDA_COMPILER)
   enable_language(CUDA)
   message(STATUS "DEVICE -> CUDA")
@@ -57,7 +50,6 @@ if(CMAKE_CUDA_COMPILER)
 else()
   message(STATUS "DEVICE -> CPU")
 endif()
-
 # CUDA Path
 if(MSVC)
 elseif(UNIX AND NOT APPLE)
@@ -65,57 +57,48 @@ elseif(UNIX AND NOT APPLE)
 else()
   message(STATUS "CUDA is not supported on Apple device")
 endif()
-
 find_library(
   ${CUDA_TOOLKIT_ROOT_DIR}/lib64
   ${CUDA_TOOLKIT_ROOT_DIR}/lib
 )
-
 set(CMAKE_CUDA_STANDARD 14)
 set(CMAKE_CUDA_STANDARD_REQUIRED ON)
 set(CMAKE_CUDA_EXTENSIONS OFF)
 set(CUDA_LINK_LIBRARIES_KEYWORD PUBLIC)
-
 # Set compiler options
 if(MSVC)
+  option(BUILD_TESTING "Build and run tests" OFF)
   list(APPEND CUDA_NVCC_FLAGS "-Xcompiler=-bigobji")
 else()
+  option(BUILD_TESTING "Build and run tests" ON)
   list(APPEND CUDA_NVCC_FLAGS "-Xcompiler=-mf16c")
   list(APPEND CUDA_NVCC_FLAGS "-Xcompiler=-Wno-float-conversion")
   list(APPEND CUDA_NVCC_FLAGS "-Xcompiler=-fno-strict-aliasing")
   list(APPEND CUDA_NVCC_FLAGS "-Xcompiler=-fPIC")
   set(CUDA_TOOLKIT_ROOT_DIR /opt/cuda/targets/x86_64-linux)
 endif()
-
 # NOTE: This might need to change for higher CUDA version
 list(APPEND CUDA_NVCC_FLAGS "--expt-extended-lambda")
 list(APPEND CUDA_NVCC_FLAGS "--expt-relaxed-constexpr")
 # list(APPEND CUDA_NVCC_FLAGS "--use_fast_math")
 # list(APPEND CUDA_NVCC_FLAGS "-lineinfo")
-
 if(APPLE)
   set(CMAKE_CXX_FLAGS_DEBUG "-gdwarf-4")
 else()
   set(CMAKE_CUDA_FLAGS_DEBUG "-g -G")
 endif()
-
 # find_package(Python COMPONENTS Interpreter Development)
 # find_package(PythonInterp)
 find_package(Python REQUIRED COMPONENTS Interpreter Development.Module)
-
 ################################################################################
 # ADD SUBMODULES AS SUBDIRECTORIES
 ################################################################################
-
 # Add googletest
 add_subdirectory(extern/googletest)
-
 add_subdirectory(extern/pybind11)
 include_directories(${pybind11_INCLUDE_DIRS})
-
 include_directories("include")
 include_directories("test")
-
 ################################################################################
 # SOURCE FILE
 ################################################################################
@@ -131,7 +114,6 @@ file(GLOB_RECURSE CPU_SOURCES
     test/load_state_dict/*.cpp
     test/heteros/*.cpp
 )
-
 # List of files to exclude (those that were commented out)
 list(REMOVE_ITEM CPU_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/derivative_calcul_cpu.cpp
@@ -144,7 +126,6 @@ list(REMOVE_ITEM CPU_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/test/embedding/test_emb_cpu.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test/cross_val/cross_val.cpp
 )
-
 # GPU source file
 file(GLOB GPU_SOURCES_TMP
     src/*.cu
@@ -154,77 +135,60 @@ list(REMOVE_ITEM GPU_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/derivative_calcul.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/src/gpu_debug_utils.cpp
 )
-
 # Output binary folder der for different mode
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO ${CMAKE_BINARY_DIR})
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_MINSIZEREL ${CMAKE_BINARY_DIR})
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG ${CMAKE_BINARY_DIR})
-
 if(CMAKE_CUDA_COMPILER)
   include_directories(${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})
   add_library(cutagi_lib STATIC ${GPU_SOURCES})
   set_target_properties(cutagi_lib PROPERTIES CUDA_RESOLVE_DEVICE_SYMBOLS ON)
   set_target_properties(cutagi_lib PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
-
   # Set CUDA flags only on target i.e. only for files that are compiled for CUDA
   target_compile_options(cutagi_lib PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:${CUDA_NVCC_FLAGS}>)
-
   # Executablecode i.e. application
   add_executable(main main.cpp)
-
   # TODO: Remove when releasing new version
   pybind11_add_module(cutagi "src/bindings/main_bindings.cpp")
 else()
   add_library(cutagi_lib STATIC ${CPU_SOURCES})
   target_link_libraries(cutagi_lib PRIVATE ${CMAKE_DL_LIBS})
-
   # Executable code i.e. application
   add_executable(main main.cpp)
-
-
   # TODO: Remove when releasing new version
   pybind11_add_module(cutagi "src/bindings/main_bindings.cpp")
 endif()
-
 # Embedding Python into a C++ program
 target_link_libraries(main PRIVATE pybind11::embed)
 target_link_libraries(cutagi_lib PRIVATE pybind11::module)
 target_link_libraries(main PUBLIC cutagi_lib)
-
 target_link_libraries(cutagi PRIVATE cutagi_lib)
-
 ################################################################################
 # TESTS
 ################################################################################
-enable_testing()
-
-# Glob the test sources
-file(GLOB TEST_SOURCES "test/cpp_unit/*.cpp")
-
-# Add main.cpp separately to specify the entry point
-set(TEST_MAIN "test/cpp_unit/main.cpp")
-
-# Create an executable for the tests
-add_executable(run_tests ${TEST_MAIN} ${TEST_SOURCES})
-
-# Set include directories for the test executable
-target_include_directories(run_tests PRIVATE
-  ${pybind11_INCLUDE_DIRS}
-  ${CMAKE_CURRENT_SOURCE_DIR}/test/cpp_unit
-)
-
-# Link the test executable with the required libraries and cutagi_lib
-target_link_libraries(run_tests PRIVATE
-  ${Python_INCLUDE_DIRS}
-  pybind11::embed
-  gtest_main
-  cutagi_lib
-)
-
-# Discover GoogleTest tests
-include(GoogleTest)
-gtest_discover_tests(run_tests)
-
-
+if(BUILD_TESTING)
+  enable_testing()
+  # Glob the test sources
+  file(GLOB TEST_SOURCES "test/cpp_unit/*.cpp")
+  # Add main.cpp separately to specify the entry point
+  set(TEST_MAIN "test/cpp_unit/main.cpp")
+  # Create an executable for the tests
+  add_executable(run_tests ${TEST_MAIN} ${TEST_SOURCES})
+  # Set include directories for the test executable
+  target_include_directories(run_tests PRIVATE
+    ${pybind11_INCLUDE_DIRS}
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/cpp_unit
+  )
+  # Link the test executable with the required libraries and cutagi_lib
+  target_link_libraries(run_tests PRIVATE
+    ${Python_INCLUDE_DIRS}
+    pybind11::embed
+    gtest_main
+    cutagi_lib
+  )
+  # Discover GoogleTest tests
+  include(GoogleTest)
+  gtest_discover_tests(run_tests)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ PROJECT(
   LANGUAGES CXX
 )
 set(CUTAGI_VERSION "${CMAKE_PROJECT_VERSION}")
+
 # ##############################################################################
 # # C++ COMPILER SETUP
 # ##############################################################################
@@ -21,28 +22,34 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
   set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "RelWithDebInfo")
 endif()
+
 if(MSVC)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /D_CRT_SECURE_NO_WARNINGS")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP24")
 else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpic")
 endif()
+
 find_package(Threads REQUIRED)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
+
 set(CMAKE_CXX_STANDARD 14) # C++ version
 set(CMAKE_CXX_EXTENSIONS OFF) # Disable GNU extenstions
+
 if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
   set(BUILD_SHARED_LIBS ON)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -flto=auto")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -flto=auto")
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -flto=auto")
 endif()
+
 # ##############################################################################
 # # CUDA COMPILER SETUP
 # ##############################################################################
 # Check CUDA availability
 include(CheckLanguage)
 check_language(CUDA)
+
 if(CMAKE_CUDA_COMPILER)
   enable_language(CUDA)
   message(STATUS "DEVICE -> CUDA")
@@ -50,6 +57,7 @@ if(CMAKE_CUDA_COMPILER)
 else()
   message(STATUS "DEVICE -> CPU")
 endif()
+
 # CUDA Path
 if(MSVC)
 elseif(UNIX AND NOT APPLE)
@@ -57,14 +65,17 @@ elseif(UNIX AND NOT APPLE)
 else()
   message(STATUS "CUDA is not supported on Apple device")
 endif()
+
 find_library(
   ${CUDA_TOOLKIT_ROOT_DIR}/lib64
   ${CUDA_TOOLKIT_ROOT_DIR}/lib
 )
+
 set(CMAKE_CUDA_STANDARD 14)
 set(CMAKE_CUDA_STANDARD_REQUIRED ON)
 set(CMAKE_CUDA_EXTENSIONS OFF)
 set(CUDA_LINK_LIBRARIES_KEYWORD PUBLIC)
+
 # Set compiler options
 if(MSVC)
   list(APPEND CUDA_NVCC_FLAGS "-Xcompiler=-bigobji")
@@ -75,29 +86,37 @@ else()
   list(APPEND CUDA_NVCC_FLAGS "-Xcompiler=-fPIC")
   set(CUDA_TOOLKIT_ROOT_DIR /opt/cuda/targets/x86_64-linux)
 endif()
+
 # NOTE: This might need to change for higher CUDA version
 list(APPEND CUDA_NVCC_FLAGS "--expt-extended-lambda")
 list(APPEND CUDA_NVCC_FLAGS "--expt-relaxed-constexpr")
 # list(APPEND CUDA_NVCC_FLAGS "--use_fast_math")
 # list(APPEND CUDA_NVCC_FLAGS "-lineinfo")
+
 if(APPLE)
   set(CMAKE_CXX_FLAGS_DEBUG "-gdwarf-4")
 else()
   set(CMAKE_CUDA_FLAGS_DEBUG "-g -G")
 endif()
+
 # find_package(Python COMPONENTS Interpreter Development)
 # find_package(PythonInterp)
 find_package(Python REQUIRED COMPONENTS Interpreter Development.Module)
 option(BUILD_TESTING "Build and run tests" ON)
+
 ################################################################################
 # ADD SUBMODULES AS SUBDIRECTORIES
 ################################################################################
+
 # Add googletest
 add_subdirectory(extern/googletest)
+
 add_subdirectory(extern/pybind11)
 include_directories(${pybind11_INCLUDE_DIRS})
+
 include_directories("include")
 include_directories("test")
+
 ################################################################################
 # SOURCE FILE
 ################################################################################
@@ -113,6 +132,7 @@ file(GLOB_RECURSE CPU_SOURCES
     test/load_state_dict/*.cpp
     test/heteros/*.cpp
 )
+
 # List of files to exclude (those that were commented out)
 list(REMOVE_ITEM CPU_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/derivative_calcul_cpu.cpp
@@ -125,6 +145,7 @@ list(REMOVE_ITEM CPU_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/test/embedding/test_emb_cpu.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test/cross_val/cross_val.cpp
 )
+
 # GPU source file
 file(GLOB GPU_SOURCES_TMP
     src/*.cu
@@ -134,52 +155,67 @@ list(REMOVE_ITEM GPU_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/derivative_calcul.cu
     ${CMAKE_CURRENT_SOURCE_DIR}/src/gpu_debug_utils.cpp
 )
+
 # Output binary folder der for different mode
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO ${CMAKE_BINARY_DIR})
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_MINSIZEREL ${CMAKE_BINARY_DIR})
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG ${CMAKE_BINARY_DIR})
+
 if(CMAKE_CUDA_COMPILER)
   include_directories(${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})
   add_library(cutagi_lib STATIC ${GPU_SOURCES})
   set_target_properties(cutagi_lib PROPERTIES CUDA_RESOLVE_DEVICE_SYMBOLS ON)
   set_target_properties(cutagi_lib PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
+
   # Set CUDA flags only on target i.e. only for files that are compiled for CUDA
   target_compile_options(cutagi_lib PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:${CUDA_NVCC_FLAGS}>)
+
   # Executablecode i.e. application
   add_executable(main main.cpp)
+
   # TODO: Remove when releasing new version
   pybind11_add_module(cutagi "src/bindings/main_bindings.cpp")
 else()
   add_library(cutagi_lib STATIC ${CPU_SOURCES})
   target_link_libraries(cutagi_lib PRIVATE ${CMAKE_DL_LIBS})
+
   # Executable code i.e. application
   add_executable(main main.cpp)
+
   # TODO: Remove when releasing new version
   pybind11_add_module(cutagi "src/bindings/main_bindings.cpp")
 endif()
+
 # Embedding Python into a C++ program
 target_link_libraries(main PRIVATE pybind11::embed)
 target_link_libraries(cutagi_lib PRIVATE pybind11::module)
 target_link_libraries(main PUBLIC cutagi_lib)
+
 target_link_libraries(cutagi PRIVATE cutagi_lib)
+
 ################################################################################
 # TESTS
 ################################################################################
 if(BUILD_TESTING)
   enable_testing()
+
   # Glob the test sources
   file(GLOB TEST_SOURCES "test/cpp_unit/*.cpp")
+
   # Add main.cpp separately to specify the entry point
   set(TEST_MAIN "test/cpp_unit/main.cpp")
+
   # Create an executable for the tests
   add_executable(run_tests ${TEST_MAIN} ${TEST_SOURCES})
+
   # Set include directories for the test executable
   target_include_directories(run_tests PRIVATE
     ${pybind11_INCLUDE_DIRS}
     ${CMAKE_CURRENT_SOURCE_DIR}/test/cpp_unit
   )
+
   # Link the test executable with the required libraries and cutagi_lib
   target_link_libraries(run_tests PRIVATE
     ${Python_INCLUDE_DIRS}
@@ -187,6 +223,7 @@ if(BUILD_TESTING)
     gtest_main
     cutagi_lib
   )
+
   # Discover GoogleTest tests
   include(GoogleTest)
   gtest_discover_tests(run_tests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,10 +67,8 @@ set(CMAKE_CUDA_EXTENSIONS OFF)
 set(CUDA_LINK_LIBRARIES_KEYWORD PUBLIC)
 # Set compiler options
 if(MSVC)
-  option(BUILD_TESTING "Build and run tests" OFF)
   list(APPEND CUDA_NVCC_FLAGS "-Xcompiler=-bigobji")
 else()
-  option(BUILD_TESTING "Build and run tests" ON)
   list(APPEND CUDA_NVCC_FLAGS "-Xcompiler=-mf16c")
   list(APPEND CUDA_NVCC_FLAGS "-Xcompiler=-Wno-float-conversion")
   list(APPEND CUDA_NVCC_FLAGS "-Xcompiler=-fno-strict-aliasing")
@@ -90,6 +88,7 @@ endif()
 # find_package(Python COMPONENTS Interpreter Development)
 # find_package(PythonInterp)
 find_package(Python REQUIRED COMPONENTS Interpreter Development.Module)
+option(BUILD_TESTING "Build and run tests" ON)
 ################################################################################
 # ADD SUBMODULES AS SUBDIRECTORIES
 ################################################################################

--- a/src/derivative_calcul_cpu.cpp
+++ b/src/derivative_calcul_cpu.cpp
@@ -438,7 +438,7 @@ void compute_node_derv_mean_var_fc_mt(
     const int n_batch = tot_ops / num_threads;
     const int rem_batch = tot_ops % num_threads;
     int start_idx, end_idx;
-    std::thread threads[num_threads];
+    std::vector<std::thread> threads(NUM_THREADS);
 
     for (int i = 0; i < num_threads; i++) {
         if (i == 0) {
@@ -544,7 +544,7 @@ void compute_cov_d_dw_fc_mt(std::vector<float> &mda, std::vector<float> &ma,
     const int n_batch = tot_ops / num_threads;
     const int rem_batch = tot_ops % num_threads;
     int start_idx, end_idx;
-    std::thread threads[num_threads];
+    std::vector<std::thread> threads(NUM_THREADS);
 
     for (int i = 0; i < num_threads; i++) {
         if (i == 0) {
@@ -624,7 +624,7 @@ void compute_layer_derv_mean_var_fc_mt(
     const int n_batch = tot_ops / num_threads;
     const int rem_batch = tot_ops % num_threads;
     int start_idx, end_idx;
-    std::thread threads[num_threads];
+    std::vector<std::thread> threads(NUM_THREADS);
     for (int i = 0; i < num_threads; i++) {
         if (i == 0) {
             start_idx = n_batch * i;
@@ -725,7 +725,7 @@ void compute_cov_dz_fc_mt(std::vector<float> &ma, std::vector<float> &J,
     const int n_batch = tot_ops / num_threads;
     const int rem_batch = tot_ops % num_threads;
     int start_idx, end_idx;
-    std::thread threads[num_threads];
+    std::vector<std::thread> threads(NUM_THREADS);
 
     for (int i = 0; i < num_threads; i++) {
         if (i == 0) {
@@ -786,7 +786,7 @@ void compute_cov_last_current_layers_mt(
     const int n_batch = tot_ops / num_threads;
     const int rem_batch = tot_ops % num_threads;
     int start_idx, end_idx;
-    std::thread threads[num_threads];
+    std::vector<std::thread> threads(NUM_THREADS);
     for (int i = 0; i < num_threads; i++) {
         if (i == 0) {
             start_idx = n_batch * i;
@@ -836,7 +836,7 @@ void compute_cov_last_layer_minus_1_fc_mt(std::vector<float> &mw,
     const int n_batch = tot_ops / num_threads;
     const int rem_batch = tot_ops % num_threads;
     int start_idx, end_idx;
-    std::thread threads[num_threads];
+    std::vector<std::thread> threads(NUM_THREADS);
     for (int i = 0; i < num_threads; i++) {
         if (i == 0) {
             start_idx = n_batch * i;
@@ -875,7 +875,7 @@ void copy_derv_mt(std::vector<float> &md_layer_m, int ni, int no, int nn, int B,
     const int n_batch = tot_ops / num_threads;
     const int rem_batch = tot_ops % num_threads;
     int start_idx, end_idx;
-    std::thread threads[num_threads];
+    std::vector<std::thread> threads(NUM_THREADS);
     for (int i = 0; i < num_threads; i++) {
         if (i == 0) {
             start_idx = n_batch * i;
@@ -917,7 +917,7 @@ void sum_derv_mt(std::vector<float> &d_layer_m, int ni, int no, int B,
     const int n_batch = tot_ops / num_threads;
     const int rem_batch = tot_ops % num_threads;
     int start_idx, end_idx;
-    std::thread threads[num_threads];
+    std::vector<std::thread> threads(NUM_THREADS);
     for (int i = 0; i < num_threads; i++) {
         if (i == 0) {
             start_idx = n_batch * i;
@@ -957,7 +957,7 @@ void tanh_derv_mt(std::vector<float> &ma, std::vector<float> &Sa,
     const int n_batch = n / num_threads;
     const int rem_batch = n % num_threads;
     int start_idx, end_idx;
-    std::thread threads[num_threads];
+    std::vector<std::thread> threads(NUM_THREADS);
 
     for (int i = 0; i < num_threads; i++) {
         if (i == 0) {
@@ -995,7 +995,7 @@ void sigmoid_derv_mt(std::vector<float> &ma, std::vector<float> &Sa,
     const int n_batch = n / num_threads;
     const int rem_batch = n % num_threads;
     int start_idx, end_idx;
-    std::thread threads[num_threads];
+    std::vector<std::thread> threads(NUM_THREADS);
 
     for (int i = 0; i < num_threads; i++) {
         if (i == 0) {
@@ -1033,7 +1033,7 @@ void relu_derv_mt(std::vector<float> &mz, int z_pos, int n,
     const int n_batch = n / num_threads;
     const int rem_batch = n % num_threads;
     int start_idx, end_idx;
-    std::thread threads[num_threads];
+    std::vector<std::thread> threads(NUM_THREADS);
 
     for (int i = 0; i < num_threads; i++) {
         if (i == 0) {
@@ -1065,7 +1065,7 @@ void no_act_derv_mt(int z_pos, int n, unsigned int num_threads,
     const int n_batch = n / num_threads;
     const int rem_batch = n % num_threads;
     int start_idx, end_idx;
-    std::thread threads[num_threads];
+    std::vector<std::thread> threads(NUM_THREADS);
 
     for (int i = 0; i < num_threads; i++) {
         if (i == 0) {

--- a/src/lstm_layer.cpp
+++ b/src/lstm_layer.cpp
@@ -362,7 +362,7 @@ void lstm_cov_input_cell_states_mp(
     const int n_batch = tot_ops / NUM_THREADS;
     const int rem_batch = tot_ops % NUM_THREADS;
     int start_idx, end_idx;
-    std::thread threads[NUM_THREADS];
+    std::vector<std::thread> threads(NUM_THREADS);
 
     for (int i = 0; i < NUM_THREADS; i++) {
         get_multithread_indices(i, n_batch, rem_batch, start_idx, end_idx);
@@ -417,7 +417,7 @@ void lstm_cell_state_mean_var_mp(
     const int n_batch = tot_ops / NUM_THREADS;
     const int rem_batch = tot_ops % NUM_THREADS;
     int start_idx, end_idx;
-    std::thread threads[NUM_THREADS];
+    std::vector<std::thread> threads(NUM_THREADS);
 
     for (int i = 0; i < NUM_THREADS; i++) {
         get_multithread_indices(i, n_batch, rem_batch, start_idx, end_idx);
@@ -482,7 +482,7 @@ void lstm_cov_output_tanh_cell_states_mp(
     const int n_batch = tot_ops / NUM_THREADS;
     const int rem_batch = tot_ops % NUM_THREADS;
     int start_idx, end_idx;
-    std::thread threads[NUM_THREADS];
+    std::vector<std::thread> threads(NUM_THREADS);
 
     for (int i = 0; i < NUM_THREADS; i++) {
         get_multithread_indices(i, n_batch, rem_batch, start_idx, end_idx);
@@ -534,7 +534,7 @@ void lstm_hidden_state_mean_var_mp(
     const int n_batch = tot_ops / NUM_THREADS;
     const int rem_batch = tot_ops % NUM_THREADS;
     int start_idx, end_idx;
-    std::thread threads[NUM_THREADS];
+    std::vector<std::thread> threads(NUM_THREADS);
 
     for (int i = 0; i < NUM_THREADS; i++) {
         get_multithread_indices(i, n_batch, rem_batch, start_idx, end_idx);
@@ -585,7 +585,7 @@ void lstm_cat_activations_and_prev_states_mp(std::vector<float> &a,
     const int n_batch = tot_ops / NUM_THREADS;
     const int rem_batch = tot_ops % NUM_THREADS;
     int start_idx, end_idx;
-    std::thread threads[NUM_THREADS];
+    std::vector<std::thread> threads(NUM_THREADS);
 
     for (int i = 0; i < NUM_THREADS; i++) {
         get_multithread_indices(i, n_batch, rem_batch, start_idx, end_idx);
@@ -676,7 +676,7 @@ void lstm_delta_mean_var_z_mp(
     const int n_batch = tot_ops / NUM_THREADS;
     const int rem_batch = tot_ops % NUM_THREADS;
     int start_idx, end_idx;
-    std::thread threads[NUM_THREADS];
+    std::vector<std::thread> threads(NUM_THREADS);
 
     for (int i = 0; i < NUM_THREADS; i++) {
         get_multithread_indices(i, n_batch, rem_batch, start_idx, end_idx);
@@ -880,7 +880,7 @@ void lstm_delta_mean_var_w_mp(
     const int n_batch = tot_ops / NUM_THREADS;
     const int rem_batch = tot_ops % NUM_THREADS;
     int start_idx, end_idx;
-    std::thread threads[NUM_THREADS];
+    std::vector<std::thread> threads(NUM_THREADS);
 
     for (int i = 0; i < NUM_THREADS; i++) {
         get_multithread_indices(i, n_batch, rem_batch, start_idx, end_idx);
@@ -986,7 +986,7 @@ void lstm_delta_mean_var_b_mp(
     const int n_batch = tot_ops / NUM_THREADS;
     const int rem_batch = tot_ops % NUM_THREADS;
     int start_idx, end_idx;
-    std::thread threads[NUM_THREADS];
+    std::vector<std::thread> threads(NUM_THREADS);
 
     for (int i = 0; i < NUM_THREADS; i++) {
         get_multithread_indices(i, n_batch, rem_batch, start_idx, end_idx);


### PR DESCRIPTION
## Description

This pull request fixes Windows build issues for the `pytagi` package by improving cross-platform compatibility and adding proper CI support. It resolves test build failures during `pip install` on Windows and ensures wheels can be built reliably across Python versions.

---

## Changes Made

- **Thread Handling Fix**: Replaced C-style fixed-length thread arrays with `std::vector<std::thread>` to ensure compatibility with MSVC.
- **CMake Option**: Added `option(BUILD_TESTING "Build and run tests" ON)` to conditionally include test builds. This prevents CTest from being invoked during wheel packaging on Windows.
- **Windows Wheel CI**:
  - Added a `build_windows` job in `build_wheels.yml` for Python 3.10–3.12.
  - Uses `cibuildwheel` to build CPU-only wheels.
  - Disables test builds via `CMAKE_ARGS='-DBUILD_TESTING=OFF'`.
  - Downgrades NumPy to `<2.0` to avoid ABI issues on Windows with Anaconda.

---

## Related Issue(s)

Issue #94 

This PR allows to build on Windows machine for CPU executions.

---

## Checklist

- [x] I have followed the project's coding conventions and style guidelines.
- [x] I have updated the documentation, if applicable.
- [x] I have rebased my branch on the latest upstream code to incorporate any changes.
- [x] I have tested the changes locally.