### PR TITLE
Feature/agvi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,6 @@ data/mnist/
 data/MNIST/
 data/traffic
 data/imagenet
-data/UCI_bench
 test_model/
 wandb/
 saved_results/param_viz

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ data/mnist/
 data/MNIST/
 data/traffic
 data/imagenet
+data/UCI_bench
 test_model/
 wandb/
 saved_results/param_viz

--- a/examples/agvi_heteros_bench.py
+++ b/examples/agvi_heteros_bench.py
@@ -1,0 +1,306 @@
+import os
+import time
+
+import fire
+import numpy as np
+import pandas as pd
+from sklearn.model_selection import train_test_split
+from tqdm import tqdm
+from ucimlrepo import fetch_ucirepo
+
+import pytagi.metric as metric
+from examples.data_loader import RegressionDataLoader
+from examples.time_series_forecasting import PredictionViz
+from pytagi import Normalizer
+from pytagi.nn import (
+    AGVI,
+    Exp,
+    Linear,
+    OutputUpdater,
+    ReLU,
+    Sequential,
+    SplitActivation,
+)
+
+
+def predict(batch_size, train_dtl, test_dtl, net, cuda):
+    test_batch_iter = test_dtl.create_data_loader(batch_size, shuffle=True)
+    mu_preds = []
+    var_preds = []
+    y_test = []
+    x_test = []
+
+    for x, y in test_batch_iter:
+        # Prediction
+        m_pred, v_pred = net(x)
+
+        mu_preds.extend(m_pred[::2])
+        var_preds.extend(v_pred[::2] + m_pred[1::2])
+        # mu_preds.extend(m_pred)
+        # var_preds.extend(v_pred)
+
+        x_test.extend(x)
+        y_test.extend(y)
+
+    mu_preds = np.array(mu_preds)
+    std_preds = np.array(var_preds) ** 0.5
+    y_test = np.array(y_test)
+    x_test = np.array(x_test)
+
+    mu_preds = Normalizer.unstandardize(
+        mu_preds, train_dtl.y_mean, train_dtl.y_std
+    )
+    std_preds = Normalizer.unstandardize_std(std_preds, train_dtl.y_std)
+
+    y_test = Normalizer.unstandardize(y_test, train_dtl.y_mean, train_dtl.y_std)
+
+    # Compute log-likelihood
+    mse = metric.mse(mu_preds, y_test)
+    log_lik = metric.log_likelihood(
+        prediction=mu_preds, observation=y_test, std=std_preds
+    )
+
+    return mse**0.5, log_lik
+
+
+def download_and_split_dataset(data_name: str, n_splits: int):
+    """
+    Downloads the dataset from ucimlrepo, handles preprocessing,
+    and creates the necessary train/test split files.
+    """
+    base_dir = f"./data/UCI_bench/{data_name}"
+    data_dir = os.path.join(base_dir, "data")
+    os.makedirs(data_dir, exist_ok=True)
+
+    # Dictionary to map data_name to ucimlrepo id or name
+    # You may need to update this for all datasets you use.
+    # Check the ucimlrepo documentation for the correct IDs.
+    dataset_map = {
+        "Boston_housing": 531,
+        "Concrete": 165,
+        "Energy": 242,
+        "Yacht": 266,
+        "Wine": 186,
+        "Kin8nm": 273,
+        "Naval": 643,
+        "Power-plant": 294,
+        "Protein": 420,
+    }
+
+    if data_name in dataset_map:
+        dataset = fetch_ucirepo(id=dataset_map[data_name])
+    else:
+        # Fallback to name if ID is not found
+        dataset = fetch_ucirepo(name=data_name)
+
+    if dataset is None:
+        raise ValueError(f"Dataset {data_name} not found in ucimlrepo.")
+
+    # Combine features and targets into a single DataFrame
+    X = dataset.data.features
+    y = dataset.data.targets
+    data = pd.concat([X, y], axis=1).dropna()
+
+    # Save the combined data for easy access
+    data.to_csv(
+        os.path.join(data_dir, "data.txt"), index=False, header=False, sep=" "
+    )
+
+    # Generate and save the train/test splits
+    for split in range(n_splits):
+        np.random.seed(split)  # Ensure reproducibility for each split
+        train_data, test_data = train_test_split(
+            data, test_size=0.2, random_state=42
+        )
+
+        # Save the indices
+        np.savetxt(
+            os.path.join(data_dir, f"index_train_{split}.txt"),
+            train_data.index.values,
+            fmt="%d",
+        )
+        np.savetxt(
+            os.path.join(data_dir, f"index_test_{split}.txt"),
+            test_data.index.values,
+            fmt="%d",
+        )
+
+    print(f"Dataset {data_name} downloaded and splits generated.")
+    return data_dir
+
+
+def run_benchmark(data_name: str, num_epochs, batch_size, n_splits):
+    """Run benchmark for each UCI dataset"""
+    rmse_list = []
+    log_lik_list = []
+    times_list = []
+
+    # Check and download dataset if not exists
+    data_dir = f"./data/UCI_bench/{data_name}/data"
+    if not os.path.exists(data_dir) or not os.path.exists(
+        os.path.join(data_dir, "data.txt")
+    ):
+        try:
+            download_and_split_dataset(data_name, n_splits)
+        except Exception as e:
+            print(f"Failed to download {data_name}: {e}")
+            return
+
+    num_nodes = 50
+    if data_name == "Protein":
+        num_nodes = 100
+        n_splits = 5
+    if data_name == "Yacht":
+        batch_size = 5
+
+    for split in range(n_splits):
+        # Read and split the data
+        data = np.loadtxt(os.path.join(data_dir, "data.txt"))
+        train_index = np.loadtxt(
+            os.path.join(data_dir, f"index_train_{split}.txt")
+        ).astype(int)
+        test_index = np.loadtxt(
+            os.path.join(data_dir, f"index_test_{split}.txt")
+        ).astype(int)
+
+        train_data = data[train_index]
+        test_data = data[test_index]
+
+        # Split train data into training and validation
+        train_data, val_data = train_test_split(
+            train_data, test_size=0.1, random_state=42
+        )
+
+        # Save the training and testing data in x and y files
+        x_train_file = f"./data/UCI_bench/{data_name}/x_train.csv"
+        y_train_file = f"./data/UCI_bench/{data_name}/y_train.csv"
+        x_test_file = f"./data/UCI_bench/{data_name}/x_test.csv"
+        y_test_file = f"./data/UCI_bench/{data_name}/y_test.csv"
+        x_val_file = f"./data/UCI_bench/{data_name}/x_val.csv"
+        y_val_file = f"./data/UCI_bench/{data_name}/y_val.csv"
+
+        np.savetxt(x_train_file, train_data[:, :-1], delimiter=",")
+        np.savetxt(y_train_file, train_data[:, -1], delimiter=",")
+        np.savetxt(x_test_file, test_data[:, :-1], delimiter=",")
+        np.savetxt(y_test_file, test_data[:, -1], delimiter=",")
+        np.savetxt(x_val_file, val_data[:, :-1], delimiter=",")
+        np.savetxt(y_val_file, val_data[:, -1], delimiter=",")
+
+        train_dtl = RegressionDataLoader(
+            x_file=x_train_file, y_file=y_train_file
+        )
+        test_dtl = RegressionDataLoader(
+            x_file=x_test_file,
+            y_file=y_test_file,
+            x_mean=train_dtl.x_mean,
+            x_std=train_dtl.x_std,
+            y_mean=train_dtl.y_mean,
+            y_std=train_dtl.y_std,
+        )
+        val_dtl = RegressionDataLoader(
+            x_file=x_val_file,
+            y_file=y_val_file,
+            x_mean=train_dtl.x_mean,
+            x_std=train_dtl.x_std,
+            y_mean=train_dtl.y_mean,
+            y_std=train_dtl.y_std,
+        )
+
+        num_inputs = pd.read_csv(x_train_file, header=None).shape[1]
+        cuda = True
+
+        net = Sequential(
+            Linear(num_inputs, num_nodes),
+            ReLU(),
+            Linear(num_nodes, num_nodes),
+            ReLU(),
+            Linear(num_nodes, 2),
+            # AGVI(Exp(), overfit_mu=True),
+            SplitActivation(Exp()),
+        )
+
+        if cuda:
+            net.to_device("cuda")
+        else:
+            net.set_threads(8)
+
+        out_updater = OutputUpdater(net.device)
+        delta = 0.01
+        patience = 5
+        best_log_lik = -np.inf
+        counter = 0
+
+        start_time = time.time()
+
+        for epoch in range(num_epochs):
+            batch_iter = train_dtl.create_data_loader(batch_size)
+
+            for x, y in batch_iter:
+                m_pred, _ = net(x)
+                out_updater.update_heteros(
+                    output_states=net.output_z_buffer,
+                    mu_obs=y,
+                    # var_obs=np.zeros_like(y),
+                    delta_states=net.input_delta_z_buffer,
+                )
+                net.backward()
+                net.step()
+
+            rmse, log_lik = predict(batch_size, train_dtl, val_dtl, net, cuda)
+
+            if (log_lik - best_log_lik) > delta:
+                best_log_lik = log_lik
+                counter = 0
+            else:
+                counter += 1
+                if counter == patience:
+                    print(f"Early stopping at epoch {epoch}")
+                    break
+
+        times_list.append(time.time() - start_time)
+
+        rmse, log_lik = predict(batch_size, train_dtl, test_dtl, net, cuda)
+
+        rmse_list.append(rmse)
+        log_lik_list.append(log_lik)
+
+        print(
+            f"Split {split + 1}/{n_splits} - RMSE: {rmse: 0.3f}, Log-likelihood: {log_lik: 0.3f}"
+        )
+
+    print("#############")
+    print(
+        f"RMSE           : {np.mean(rmse_list): 0.3f} +- {np.std(rmse_list): 0.3f}"
+    )
+    print(
+        f"Log-likelihood: {np.mean(log_lik_list): 0.3f} +- {np.std(log_lik_list): 0.3f}"
+    )
+    print(
+        f"Time           : {np.mean(times_list): 0.3f} +- {np.std(times_list): 0.3f}"
+    )
+    print("#############")
+
+
+def main():
+    """Run benchmark for regression tasks on UCI dataset"""
+
+    data_names = [
+        "Boston_housing",
+        "Concrete",
+        "Energy",
+        "Yacht",
+        "Wine",
+        "Kin8nm",
+        "Naval",
+        "Power-plant",
+        "Protein",
+    ]
+    # data_names = ["Protein"]
+
+    for data_name in data_names:
+        print(f"Running benchmark for {data_name}")
+        run_benchmark(data_name, num_epochs=100, batch_size=10, n_splits=20)
+
+
+if __name__ == "__main__":
+    fire.Fire(main)

--- a/examples/regression_heteros.py
+++ b/examples/regression_heteros.py
@@ -58,8 +58,8 @@ def main(num_epochs: int = 20, batch_size: int = 10):
         Linear(128, 128),
         ReLU(),
         Linear(128, 2),
-        AGVI(Exp(), overfit_mu=True),
-        # SplitActivation(Exp())
+        # AGVI(Exp(), overfit_mu=True),
+        SplitActivation(Exp()),
     )
     if cuda:
         net.to_device("cuda")
@@ -77,13 +77,13 @@ def main(num_epochs: int = 20, batch_size: int = 10):
         for x, y in batch_iter:
             # Feed forward
             m_pred, v_pred = net(x)
-            # m_pred = m_pred[::2]
+            m_pred = m_pred[::2]
 
             # Update output layer
-            out_updater.update(
+            out_updater.update_heteros(
                 output_states=net.output_z_buffer,
                 mu_obs=y,
-                var_obs=np.zeros_like(y),
+                # var_obs=np.zeros_like(y),
                 delta_states=net.input_delta_z_buffer,
             )
 
@@ -118,10 +118,10 @@ def main(num_epochs: int = 20, batch_size: int = 10):
         # Predicion
         m_pred, v_pred = net(x)
 
-        # var_preds.extend(m_pred[1::2] + v_pred[::2])
-        # mu_preds.extend(m_pred[::2])
-        var_preds.extend(v_pred)
-        mu_preds.extend(m_pred)
+        var_preds.extend(m_pred[1::2] + v_pred[::2])
+        mu_preds.extend(m_pred[::2])
+        # var_preds.extend(v_pred)
+        # mu_preds.extend(m_pred)
 
         x_test.extend(x)
         y_test.extend(y)

--- a/examples/softmax_cifar.py
+++ b/examples/softmax_cifar.py
@@ -135,14 +135,14 @@ def load_datasets(batch_size: int):
     return train_loader, test_loader
 
 
-def main(num_epochs: int = 100, batch_size: int = 128, sigma_v: float = 0.05):
+def main(num_epochs: int = 100, batch_size: int = 128, sigma_v: float = 0.0):
     """
     Run classification training on the CIFAR-10 dataset using PyTAGI.
     """
     train_loader, test_loader = load_datasets(batch_size)
 
     # Initialize network
-    net = CNN_NET
+    # net = CNN_NET
     net = resnet18_cifar10(is_remax=True, gain_w=1.0, gain_b=1.0)
     net.to_device("cuda" if pytagi.cuda.is_available() else "cpu")
 

--- a/examples/softmax_cifar.py
+++ b/examples/softmax_cifar.py
@@ -28,6 +28,7 @@ from pytagi.nn import (
     ReLU,
     Remax,
     Sequential,
+    Softmax,
 )
 
 torch.manual_seed(17)
@@ -52,7 +53,8 @@ CNN_NET = Sequential(
     Linear(64 * 4 * 4, 256),
     MixtureReLU(),
     Linear(256, 10, gain_weight=0.25, gain_bias=0.25),
-    Remax(),
+    # Remax(),
+    Softmax(),
 )
 
 
@@ -160,15 +162,23 @@ def main(num_epochs: int = 100, batch_size: int = 128, sigma_v: float = 0.0):
         for _, (data, target) in enumerate(pbar):
             # Feedforward and backward pass
             m_pred, v_pred = net(data)
+            m_pred = m_pred[::2]
+
+            # if inf or nan in m_pred or v_pred
+            # if np.any(np.isnan(m_pred)) or np.any(np.isinf(m_pred)):
+            #     print("NaN or Inf in m_pred")
+            #     break
 
             # Convert labels to one-hot encoding
             y = one_hot_encode(target)
+            # y[y == 0] = -0.4
+            # y[y == 1] = 16.5
 
             # Update output layers
-            out_updater.update(
+            out_updater.update_heteros(
                 output_states=net.output_z_buffer,
                 mu_obs=y,
-                var_obs=var_y,
+                # var_obs=var_y,
                 delta_states=net.input_delta_z_buffer,
             )
 
@@ -194,6 +204,7 @@ def main(num_epochs: int = 100, batch_size: int = 128, sigma_v: float = 0.0):
 
         for data, target in test_loader:
             m_pred, v_pred = net(data)
+            m_pred = m_pred[::2]
 
             # Calculate test error
             pred = np.reshape(m_pred, (batch_size, 10))
@@ -207,6 +218,8 @@ def main(num_epochs: int = 100, batch_size: int = 128, sigma_v: float = 0.0):
             f"Train Error: {train_error/num_train_samples * 100:.2f}% | "
             f"Test Error: {test_error_rate:.2f}%"
         )
+
+        net.save(f".examples/softmax_cifar_epoch{epoch+1}.bin")
 
 
 if __name__ == "__main__":

--- a/examples/softmax_mnist.py
+++ b/examples/softmax_mnist.py
@@ -40,7 +40,7 @@ FNN = Sequential(
     ReLU(),
     Linear(128, 20),
     AGVI(CELU(), overfit_mu=False),
-    # SplitActivation(Exp()),
+    # SplitActivation(Exp(), Remax()),
     Remax(),
 )
 
@@ -92,7 +92,7 @@ CNN_BATCHNORM = Sequential(
     Linear(32 * 4 * 4, 100),
     ReLU(),
     Linear(100, 20),
-    AGVI(Exp(), overfit_mu=False),
+    AGVI(CELU(), overfit_mu=False),
     Remax(),
     # SplitActivation(Exp(), Remax()),
 )
@@ -104,7 +104,7 @@ def one_hot_encode(labels, num_classes=10):
     return F.one_hot(labels, num_classes=num_classes).numpy().flatten()
 
 
-def main(num_epochs: int = 20, batch_size: int = 128, sigma_v: float = 0.0):
+def main(num_epochs: int = 20, batch_size: int = 128, sigma_v: float = 0.05):
     """
     Run classification training on the MNIST dataset using PyTAGI.
     """
@@ -152,8 +152,8 @@ def main(num_epochs: int = 20, batch_size: int = 128, sigma_v: float = 0.0):
             m_pred, v_pred = net(x)
             # v_pred = m_pred[1::2] + v_pred[::2]
             # m_pred = m_pred[::2]
-            print("m_pred: ", m_pred)
-            print("v_pred: ", v_pred)
+            # print("m_pred: ", m_pred)
+            # print("v_pred: ", v_pred)
 
             # Update output layers
             out_updater.update(

--- a/examples/softmax_mnist.py
+++ b/examples/softmax_mnist.py
@@ -25,23 +25,26 @@ from pytagi.nn import (
     Linear,
     MaxPool2d,
     MixtureReLU,
+    MixtureTanh,
     OutputUpdater,
     ReLU,
     Remax,
     Sequential,
     Softmax,
+    Softplus,
     SplitActivation,
 )
 
 FNN = Sequential(
-    Linear(784, 128),
+    Linear(784, 128, gain_weight=1.0, gain_bias=1.0),
     ReLU(),
-    Linear(128, 128),
+    Linear(128, 128, gain_weight=1.0, gain_bias=1.0),
     ReLU(),
-    Linear(128, 20),
-    AGVI(CELU(), overfit_mu=False),
+    Linear(128, 10, gain_weight=1.0, gain_bias=1.0),
+    # AGVI(Softplus(), overfit_mu=False),
     # SplitActivation(Exp(), Remax()),
-    Remax(),
+    # Remax(),
+    Softmax(),
 )
 
 FNN_BATCHNORM = Sequential(
@@ -92,9 +95,10 @@ CNN_BATCHNORM = Sequential(
     Linear(32 * 4 * 4, 100),
     ReLU(),
     Linear(100, 20),
-    AGVI(CELU(), overfit_mu=False),
-    Remax(),
-    # SplitActivation(Exp(), Remax()),
+    # AGVI(Softplus(), overfit_mu=False),
+    # Remax(),
+    # Softmax(),
+    SplitActivation(Exp(), Softmax()),
 )
 
 
@@ -104,7 +108,7 @@ def one_hot_encode(labels, num_classes=10):
     return F.one_hot(labels, num_classes=num_classes).numpy().flatten()
 
 
-def main(num_epochs: int = 20, batch_size: int = 128, sigma_v: float = 0.05):
+def main(num_epochs: int = 20, batch_size: int = 128, sigma_v: float = 0.0):
     """
     Run classification training on the MNIST dataset using PyTAGI.
     """
@@ -129,8 +133,10 @@ def main(num_epochs: int = 20, batch_size: int = 128, sigma_v: float = 0.05):
     )
 
     # Initialize network
-    net = FNN
+    net = CNN_BATCHNORM
     net.to_device("cuda" if pytagi.cuda.is_available() else "cpu")
+
+    # net.load(".examples/softmax_mnist_epoch20.bin")
 
     out_updater = OutputUpdater(net.device)
 
@@ -142,24 +148,38 @@ def main(num_epochs: int = 20, batch_size: int = 128, sigma_v: float = 0.05):
         train_error = 0
         num_train_samples = 0
 
+        all_m_pred = []
+        all_v_pred = []
+
         pbar = tqdm(train_loader, desc=f"Epoch {epoch+1}/{num_epochs}")
         for batch_idx, (data, target) in enumerate(pbar):
             # Prepare data
             x = data.numpy().flatten()  # Flatten the images
             y = one_hot_encode(target).flatten()  # Convert to one-hot encoding
 
+            # y[y == 0] = -0.4
+            # y[y == 1] = 16.5
+
             # Feedforward and backward pass
             m_pred, v_pred = net(x)
-            # v_pred = m_pred[1::2] + v_pred[::2]
-            # m_pred = m_pred[::2]
-            # print("m_pred: ", m_pred)
-            # print("v_pred: ", v_pred)
+            v_pred = m_pred[1::2] + v_pred[::2]
+            m_pred = m_pred[::2]
+            print("m_pred: ", m_pred)
+            print("v_pred: ", v_pred)
+            all_m_pred.append(m_pred)
+            all_v_pred.append(v_pred)
+
+            # print("Probability statistics:")
+            # print("E[mu]: ", np.mean(m_pred))
+            # print("Std[mu]: ", np.std(m_pred))
+            # print("E[var]: ", np.mean(v_pred))
+            # print("Std[var]: ", np.std(v_pred))
 
             # Update output layers
-            out_updater.update(
+            out_updater.update_heteros(
                 output_states=net.output_z_buffer,
                 mu_obs=y,
-                var_obs=var_y,
+                # var_obs=var_y,
                 delta_states=net.input_delta_z_buffer,
             )
 
@@ -178,6 +198,30 @@ def main(num_epochs: int = 20, batch_size: int = 128, sigma_v: float = 0.05):
                 {"train_error": f"{train_error/num_train_samples:.2f}%"}
             )
 
+        average_m_pred = np.mean(np.concatenate(all_m_pred))
+        average_v_pred = np.mean(np.concatenate(all_v_pred))
+        std_v_m_pred = np.std(np.concatenate(all_m_pred))
+        std_v_pred = np.std(np.concatenate(all_v_pred))
+
+        average_v_pred_positive_m_pred = np.mean(
+            np.concatenate(all_v_pred)[np.concatenate(all_m_pred) > 0]
+        )
+        average_v_pred_negative_m_pred = np.mean(
+            np.concatenate(all_v_pred)[np.concatenate(all_m_pred) < 0]
+        )
+        print("Average mu prediction: ", average_m_pred)
+        print("Average var prediction: ", average_v_pred)
+        print("Std mu prediction: ", std_v_m_pred)
+        print("Std var prediction: ", std_v_pred)
+        print(
+            "Average var prediction (positive mu): ",
+            average_v_pred_positive_m_pred,
+        )
+        print(
+            "Average var prediction (negative mu): ",
+            average_v_pred_negative_m_pred,
+        )
+
         # Testing
         net.eval()
         test_error = 0
@@ -186,7 +230,7 @@ def main(num_epochs: int = 20, batch_size: int = 128, sigma_v: float = 0.05):
         for data, target in test_loader:
             x = data.numpy().flatten()
             m_pred, v_pred = net(x)
-            # m_pred = m_pred[::2]
+            m_pred = m_pred[::2]
 
             # Calculate test error
             pred = np.reshape(m_pred, (batch_size, 10))
@@ -200,6 +244,8 @@ def main(num_epochs: int = 20, batch_size: int = 128, sigma_v: float = 0.05):
             f"Train Error: {train_error/num_train_samples * 100:.2f}% | "
             f"Test Error: {test_error_rate:.2f}%"
         )
+
+        # net.save(f".examples/softmax_mnist_epoch{epoch+1}.bin")
 
 
 if __name__ == "__main__":

--- a/examples/softmax_mnist.py
+++ b/examples/softmax_mnist.py
@@ -14,10 +14,12 @@ from tqdm import tqdm
 
 import pytagi
 from pytagi.nn import (
+    AGVI,
     AvgPool2d,
     BatchNorm2d,
     ClosedFormSoftmax,
     Conv2d,
+    Exp,
     LayerNorm,
     Linear,
     MaxPool2d,
@@ -69,8 +71,9 @@ CNN = Sequential(
     AvgPool2d(3, 2),
     Linear(32 * 4 * 4, 128),
     ReLU(),
-    Linear(128, 10),
-    ClosedFormSoftmax(),
+    Linear(128, 20),
+    AGVI(Exp(), overfit_mu=True),
+    # ClosedFormSoftmax(),
 )
 
 CNN_BATCHNORM = Sequential(
@@ -95,7 +98,7 @@ def one_hot_encode(labels, num_classes=10):
     return F.one_hot(labels, num_classes=num_classes).numpy().flatten()
 
 
-def main(num_epochs: int = 20, batch_size: int = 128, sigma_v: float = 0.05):
+def main(num_epochs: int = 20, batch_size: int = 128, sigma_v: float = 0.00):
     """
     Run classification training on the MNIST dataset using PyTAGI.
     """

--- a/examples/tagi_resnet_model.py
+++ b/examples/tagi_resnet_model.py
@@ -1,6 +1,8 @@
 import numpy as np
 
 from pytagi.nn import (
+    AGVI,
+    CELU,
     AvgPool2d,
     BatchNorm2d,
     Conv2d,
@@ -131,7 +133,8 @@ def resnet18_cifar10(
     if is_remax:
         final_layers = [
             AvgPool2d(4),
-            Linear(512, 10, gain_weight=gain_w, gain_bias=gain_b),
+            Linear(512, 20, gain_weight=gain_w, gain_bias=gain_b),
+            AGVI(CELU(), overfit_mu=False),
             Remax(),
         ]
     else:

--- a/examples/tagi_resnet_model.py
+++ b/examples/tagi_resnet_model.py
@@ -6,6 +6,7 @@ from pytagi.nn import (
     AvgPool2d,
     BatchNorm2d,
     Conv2d,
+    Exp,
     LayerBlock,
     Linear,
     MixtureReLU,
@@ -13,6 +14,9 @@ from pytagi.nn import (
     Remax,
     ResNetBlock,
     Sequential,
+    Softmax,
+    Softplus,
+    SplitActivation,
 )
 
 
@@ -134,8 +138,10 @@ def resnet18_cifar10(
         final_layers = [
             AvgPool2d(4),
             Linear(512, 20, gain_weight=gain_w, gain_bias=gain_b),
-            AGVI(CELU(), overfit_mu=False),
-            Remax(),
+            # AGVI(Softplus(), overfit_mu=False),
+            # Softmax(),
+            SplitActivation(Exp(), Softmax()),
+            # Remax(),
         ]
     else:
         final_layers = [

--- a/include/activation.h
+++ b/include/activation.h
@@ -110,7 +110,8 @@ void agvi_backward_chunk(int start_chunk, int end_chunk,
                          const BaseHiddenStates &stored_output_states,
                          const BaseHiddenStates &stored_inner_output_states,
                          const BaseHiddenStates &stored_input_states,
-                         bool overfit_mu);
+                         const BaseHiddenStates &stored_even_output_states,
+                         bool overfit_mu, bool has_even_layer);
 
 void agvi_backward_mp(int n, unsigned int num_threads,
                       BaseDeltaStates &input_delta_states,
@@ -118,7 +119,8 @@ void agvi_backward_mp(int n, unsigned int num_threads,
                       const BaseHiddenStates &stored_output_states,
                       const BaseHiddenStates &stored_inner_output_states,
                       const BaseHiddenStates &stored_input_states,
-                      bool overfit_mu);
+                      const BaseHiddenStates &stored_even_output_states,
+                      bool overfit_mu, bool has_even_layer);
 
 ////////////////////////////////////////////////////////////////////////////////
 /// ReLU
@@ -779,7 +781,8 @@ class AGVI : public BaseLayer {
      * to encourage overfitting. Defaults to true.
      * @param agvi If true, uses the AGVI learned noise model. Defaults to true.
      */
-    explicit AGVI(std::shared_ptr<BaseLayer> activation_layer,
+    explicit AGVI(std::shared_ptr<BaseLayer> odd_layer,
+                  std::shared_ptr<BaseLayer> even_layer = nullptr,
                   bool overfit_mu = true, bool agvi = true);
 
     ~AGVI();
@@ -813,8 +816,15 @@ class AGVI : public BaseLayer {
     std::unique_ptr<BaseLayer> to_cuda(int device_idx = 0) override;
 #endif
 
+    // Runtime configuration
+    void set_overfit_mu(bool overfit_mu) { m_overfit_mu = overfit_mu; }
+    bool get_overfit_mu() const { return m_overfit_mu; }
+    void set_agvi(bool agvi) { m_agvi = agvi; }
+    bool get_agvi() const { return m_agvi; }
+
    private:
-    std::shared_ptr<BaseLayer> m_activation_layer;
+    std::shared_ptr<BaseLayer> m_odd_layer;
+    std::shared_ptr<BaseLayer> m_even_layer;
     bool m_overfit_mu;
     bool m_agvi;
 
@@ -822,4 +832,5 @@ class AGVI : public BaseLayer {
     BaseHiddenStates m_stored_inner_output_states;
     BaseHiddenStates m_stored_output_states;
     BaseHiddenStates m_stored_input_states;
+    BaseHiddenStates m_stored_even_output_states;
 };

--- a/include/activation.h
+++ b/include/activation.h
@@ -64,11 +64,9 @@ void mixture_tanh_mean_var(std::vector<float> &mu_z, std::vector<float> &var_z,
                            std::vector<float> &mu_a, std::vector<float> &jcb,
                            std::vector<float> &var_a);
 
-void mixture_tanh_mean_var_mp(std::vector<float> &mu_z,
-                              std::vector<float> &var_z, int n,
-                              unsigned int num_threads,
-                              std::vector<float> &mu_a, std::vector<float> &jcb,
-                              std::vector<float> &var_a);
+void celu_mean_var_mp(std::vector<float> &mu_z, std::vector<float> &var_z,
+                      int n, unsigned int num_threads, std::vector<float> &mu_a,
+                      std::vector<float> &jcb, std::vector<float> &var_a);
 
 void softplus_mean_var(std::vector<float> &mu_z, std::vector<float> &var_z,
                        int start_chunk, int end_chunk, std::vector<float> &mu_a,
@@ -357,6 +355,50 @@ class MixtureTanh : public BaseLayer {
     // required for bwd_states
     MixtureTanh(MixtureTanh &&) = default;
     MixtureTanh &operator=(MixtureTanh &&) = default;
+
+    std::string get_layer_info() const override;
+
+    std::string get_layer_name() const override;
+
+    LayerType get_layer_type() const override;
+
+    void forward(BaseHiddenStates &input_states,
+                 BaseHiddenStates &output_states,
+                 BaseTempStates &temp_states) override;
+
+    using BaseLayer::backward;
+
+    void allocate_param_delta() override {};
+
+    void update_weights() override {};
+
+    void update_biases() override {};
+
+    void save(std::ofstream &file) override {};
+
+    void load(std::ifstream &file) override {};
+
+#ifdef USE_CUDA
+    std::unique_ptr<BaseLayer> to_cuda(int device_idx = 0) override;
+#endif
+};
+
+////////////////////////////////////////////////////////////////////////////////
+/// CELU
+////////////////////////////////////////////////////////////////////////////////
+class CELU : public BaseLayer {
+   public:
+    CELU();
+    ~CELU();
+
+    // Delete copy constructor and copy assignment
+    CELU(const CELU &) = delete;
+    CELU &operator=(const CELU &) = delete;
+
+    // Optionally implement move constructor and move assignment. This is
+    // required for bwd_states
+    CELU(CELU &&) = default;
+    CELU &operator=(CELU &&) = default;
 
     std::string get_layer_info() const override;
 

--- a/include/activation.h
+++ b/include/activation.h
@@ -93,17 +93,34 @@ void softmax_mean_var(std::vector<float> &mu_z, std::vector<float> &var_z,
                       int no, int batch_size, std::vector<float> &mu_a,
                       std::vector<float> &jcb, std::vector<float> &var_a);
 
-void even_exp_mean_var(std::vector<float> const &mu_z,
-                       std::vector<float> const &var_z,
-                       std::vector<float> &jcb_z, int start_chunk,
-                       int end_chunk, std::vector<float> &mu_a,
-                       std::vector<float> &var_a, std::vector<float> &jcb_a);
+void exp_mean_var(std::vector<float> const &mu_z,
+                  std::vector<float> const &var_z, std::vector<float> &jcb_z,
+                  int start_chunk, int end_chunk, std::vector<float> &mu_a,
+                  std::vector<float> &var_a, std::vector<float> &jcb_a,
+                  float scale, float shift);
 
-void even_exp_mean_var_mp(std::vector<float> const &mu_z,
-                          std::vector<float> const &var_z,
-                          std::vector<float> const &jcb_z, int n,
-                          unsigned int num_threads, std::vector<float> &mu_a,
-                          std::vector<float> &var_a, std::vector<float> &jcb_a);
+void exp_mean_var_mp(std::vector<float> const &mu_z,
+                     std::vector<float> const &var_z,
+                     std::vector<float> const &jcb_z, int n,
+                     unsigned int num_threads, std::vector<float> &mu_a,
+                     std::vector<float> &var_a, std::vector<float> &jcb_a,
+                     float scale, float shift);
+
+void agvi_backward_chunk(int start_chunk, int end_chunk,
+                         BaseDeltaStates &input_delta_states,
+                         BaseDeltaStates &output_delta_states,
+                         const BaseHiddenStates &stored_output_states,
+                         const BaseHiddenStates &stored_inner_output_states,
+                         const BaseHiddenStates &stored_input_states,
+                         bool overfit_mu);
+
+void agvi_backward_mp(int n, unsigned int num_threads,
+                      BaseDeltaStates &input_delta_states,
+                      BaseDeltaStates &output_delta_states,
+                      const BaseHiddenStates &stored_output_states,
+                      const BaseHiddenStates &stored_inner_output_states,
+                      const BaseHiddenStates &stored_input_states,
+                      bool overfit_mu);
 
 ////////////////////////////////////////////////////////////////////////////////
 /// ReLU
@@ -615,20 +632,20 @@ class ClosedFormSoftmax : public BaseLayer {
 };
 
 ////////////////////////////////////////////////////////////////////////////////
-/// EvenExp
+/// Exp
 ////////////////////////////////////////////////////////////////////////////////
-class EvenExp : public BaseLayer {
+class Exp : public BaseLayer {
    public:
-    EvenExp();
-    ~EvenExp();
+    Exp(float scale = 1.0f, float shift = 0.0f);
+    ~Exp();
 
     // Delete copy constructor and copy assignment
-    EvenExp(const EvenExp &) = delete;
-    EvenExp &operator=(const EvenExp &) = delete;
+    Exp(const Exp &) = delete;
+    Exp &operator=(const Exp &) = delete;
 
     // Optionally implement move constructor and move assignment
-    EvenExp(EvenExp &&) = default;
-    EvenExp &operator=(EvenExp &&) = default;
+    Exp(Exp &&) = default;
+    Exp &operator=(Exp &&) = default;
 
     std::string get_layer_info() const override;
 
@@ -652,7 +669,115 @@ class EvenExp : public BaseLayer {
 
     void load(std::ifstream &file) override {};
 
+    float scale;
+    float shift;
+
 #ifdef USE_CUDA
     std::unique_ptr<BaseLayer> to_cuda(int device_idx = 0) override;
 #endif
+};
+
+////////////////////////////////////////////////////////////////////////////////
+/// SplitActivation (formerly EvenExp)
+////////////////////////////////////////////////////////////////////////////////
+class SplitActivation : public BaseLayer {
+   public:
+    SplitActivation(std::shared_ptr<BaseLayer> odd_layer,
+                    std::shared_ptr<BaseLayer> even_layer = nullptr);
+    ~SplitActivation();
+
+    // Delete copy constructor and copy assignment
+    SplitActivation(const SplitActivation &) = delete;
+    SplitActivation &operator=(const SplitActivation &) = delete;
+
+    // Optionally implement move constructor and move assignment
+    SplitActivation(SplitActivation &&) = default;
+    SplitActivation &operator=(SplitActivation &&) = default;
+
+    std::string get_layer_info() const override;
+
+    std::string get_layer_name() const override;
+
+    LayerType get_layer_type() const override;
+
+    void forward(BaseHiddenStates &input_states,
+                 BaseHiddenStates &output_states,
+                 BaseTempStates &temp_states) override;
+
+    using BaseLayer::backward;
+
+    void allocate_param_delta() override {};
+
+    void update_weights() override {};
+
+    void update_biases() override {};
+
+    void save(std::ofstream &file) override;
+
+    void load(std::ifstream &file) override;
+
+#ifdef USE_CUDA
+    std::unique_ptr<BaseLayer> to_cuda(int device_idx = 0) override;
+#endif
+   private:
+    std::shared_ptr<BaseLayer> odd_layer;
+    std::shared_ptr<BaseLayer> even_layer;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+/// AGVI (Approximate Gaussian Variance Inference)
+////////////////////////////////////////////////////////////////////////////////
+class AGVI : public BaseLayer {
+   public:
+    /**
+     * @brief Construct a new AGVI object
+     *
+     * @param activation_layer The inner activation layer to be used.
+     * @param overfit_mu If true, uses a different Jacobian for the mean delta
+     * to encourage overfitting. Defaults to true.
+     * @param agvi If true, uses the AGVI learned noise model. Defaults to true.
+     */
+    explicit AGVI(std::shared_ptr<BaseLayer> activation_layer,
+                  bool overfit_mu = true, bool agvi = true);
+
+    ~AGVI();
+
+    AGVI(const AGVI &) = delete;
+    AGVI &operator=(const AGVI &) = delete;
+
+    // Default move constructor and move assignment.
+    AGVI(AGVI &&) = default;
+    AGVI &operator=(AGVI &&) = default;
+
+    std::string get_layer_info() const override;
+    std::string get_layer_name() const override;
+    LayerType get_layer_type() const override;
+
+    void forward(BaseHiddenStates &input_states,
+                 BaseHiddenStates &output_states,
+                 BaseTempStates &temp_states) override;
+
+    void backward(BaseDeltaStates &input_delta_states,
+                  BaseDeltaStates &output_delta_states,
+                  BaseTempStates &temp_states,
+                  bool state_update = true) override;
+
+    void allocate_param_delta() override {};
+    void update_weights() override {};
+    void update_biases() override {};
+    void save(std::ofstream &file) override {};
+    void load(std::ifstream &file) override {};
+#ifdef USE_CUDA
+    std::unique_ptr<BaseLayer> to_cuda(int device_idx = 0) override;
+#endif
+
+   private:
+    std::shared_ptr<BaseLayer> m_activation_layer;
+    bool m_overfit_mu;
+    bool m_agvi;
+
+    // Stored hidden states for backward pass usage
+    BaseHiddenStates m_stored_inner_output_states;
+    BaseHiddenStates m_stored_output_states;
+    BaseHiddenStates m_stored_input_states;
 };

--- a/include/activation_cuda.cuh
+++ b/include/activation_cuda.cuh
@@ -41,6 +41,10 @@ __global__ void mixture_tanh_mean_var_cuda(float const *mu_z,
                                            float *mu_a, float *jcb,
                                            float *var_a);
 
+__global__ void celu_mean_var_cuda(float const *mu_z, float const *var_z,
+                                   int num_states, float *mu_a, float *jcb,
+                                   float *var_a);
+
 __global__ void softplus_mean_var_cuda(float const *mu_z, float const *var_z,
                                        int num_states, float *mu_a, float *jcb,
                                        float *var_a);
@@ -298,6 +302,45 @@ class MixtureTanhCuda : public BaseLayerCuda {
     // required for bwd_states
     MixtureTanhCuda(MixtureTanhCuda &&) = default;
     MixtureTanhCuda &operator=(MixtureTanhCuda &&) = default;
+
+    std::string get_layer_info() const override;
+
+    std::string get_layer_name() const override;
+
+    LayerType get_layer_type() const override;
+
+    void forward(BaseHiddenStates &input_states,
+                 BaseHiddenStates &output_states,
+                 BaseTempStates &temp_states) override;
+
+    using BaseLayer::backward;
+
+    void allocate_param_delta() override {};
+
+    void update_weights() override {};
+
+    void update_biases() override {};
+
+    void save(std::ofstream &file) override {};
+
+    void load(std::ifstream &file) override {};
+
+    std::unique_ptr<BaseLayer> to_host() override;
+};
+
+class CELUCuda : public BaseLayerCuda {
+   public:
+    CELUCuda();
+    ~CELUCuda();
+
+    // Delete copy constructor and copy assignment
+    CELUCuda(const CELUCuda &) = delete;
+    CELUCuda &operator=(const CELUCuda &) = delete;
+
+    // Optionally implement move constructor and move assignment. This is
+    // required for bwd_states
+    CELUCuda(CELUCuda &&) = default;
+    CELUCuda &operator=(CELUCuda &&) = default;
 
     std::string get_layer_info() const override;
 

--- a/include/base_layer.h
+++ b/include/base_layer.h
@@ -20,7 +20,8 @@ enum class LayerType {
     Activation,
     Norm,
     LayerBlock,
-    ResNetBlock
+    ResNetBlock,
+    AGVI
 };
 
 class InitArgs {

--- a/include/bindings/activation_bindings.h
+++ b/include/bindings/activation_bindings.h
@@ -17,6 +17,8 @@ void bind_mixture_sigmoid(pybind11::module_& modo);
 
 void bind_mixture_tanh(pybind11::module_& modo);
 
+void bind_celu(pybind11::module_& modo);
+
 void bind_softplus(pybind11::module_& modo);
 
 void bind_leakyrelu(pybind11::module_& modo);

--- a/include/bindings/activation_bindings.h
+++ b/include/bindings/activation_bindings.h
@@ -23,8 +23,12 @@ void bind_leakyrelu(pybind11::module_& modo);
 
 void bind_softmax(pybind11::module_& modo);
 
-void bind_even_exp(pybind11::module_& modo);
-
 void bind_remax(pybind11::module_& modo);
 
 void bind_closed_form_softmax(pybind11::module_& modo);
+
+void bind_split_activation(pybind11::module_& modo);
+
+void bind_exp(pybind11::module_& modo);
+
+void bind_agvi(pybind11::module_& modo);

--- a/pytagi/nn/__init__.py
+++ b/pytagi/nn/__init__.py
@@ -1,5 +1,6 @@
 from pytagi.nn.activation import (
     AGVI,
+    CELU,
     ClosedFormSoftmax,
     Exp,
     LeakyReLU,

--- a/pytagi/nn/__init__.py
+++ b/pytagi/nn/__init__.py
@@ -1,6 +1,7 @@
 from pytagi.nn.activation import (
+    AGVI,
     ClosedFormSoftmax,
-    EvenExp,
+    Exp,
     LeakyReLU,
     MixtureReLU,
     MixtureSigmoid,
@@ -10,6 +11,7 @@ from pytagi.nn.activation import (
     Sigmoid,
     Softmax,
     Softplus,
+    SplitActivation,
     Tanh,
 )
 from pytagi.nn.base_layer import BaseLayer

--- a/pytagi/nn/activation.py
+++ b/pytagi/nn/activation.py
@@ -81,6 +81,19 @@ class MixtureTanh(BaseLayer):
         return self._cpp_backend.get_layer_name()
 
 
+class CELU(BaseLayer):
+    """CELU"""
+
+    def __init__(self):
+        self._cpp_backend = cutagi.CELU()
+
+    def get_layer_info(self) -> str:
+        return self._cpp_backend.get_layer_info()
+
+    def get_layer_name(self) -> str:
+        return self._cpp_backend.get_layer_name()
+
+
 class Softplus(BaseLayer):
     """Softplus"""
 

--- a/pytagi/nn/activation.py
+++ b/pytagi/nn/activation.py
@@ -120,19 +120,6 @@ class Softmax(BaseLayer):
         return self._cpp_backend.get_layer_name()
 
 
-class EvenExp(BaseLayer):
-    """EvenExp"""
-
-    def __init__(self):
-        self._cpp_backend = cutagi.EvenExp()
-
-    def get_layer_info(self) -> str:
-        return self._cpp_backend.get_layer_info()
-
-    def get_layer_name(self) -> str:
-        return self._cpp_backend.get_layer_name()
-
-
 class Remax(BaseLayer):
     """Remax"""
 
@@ -151,6 +138,76 @@ class ClosedFormSoftmax(BaseLayer):
 
     def __init__(self):
         self._cpp_backend = cutagi.ClosedFormSoftmax()
+
+    def get_layer_info(self) -> str:
+        return self._cpp_backend.get_layer_info()
+
+    def get_layer_name(self) -> str:
+        return self._cpp_backend.get_layer_name()
+
+
+class SplitActivation(BaseLayer):
+    """
+    Applies a specified activation to odd-indexed inputs and another
+    (or an identity function) to even-indexed inputs.
+
+    Args:
+        odd_layer (BaseLayer): The activation layer to apply to odd-indexed elements.
+        even_layer (BaseLayer, optional): The activation layer to apply to
+                                          even-indexed elements. Defaults to None,
+                                          which is an identity transformation.
+    """
+
+    def __init__(self, odd_layer: BaseLayer, even_layer: BaseLayer = None):
+        if even_layer is None:
+            # Call C++ constructor with one argument
+            self._cpp_backend = cutagi.SplitActivation(odd_layer._cpp_backend)
+        else:
+            # Call C++ constructor with two arguments
+            self._cpp_backend = cutagi.SplitActivation(
+                odd_layer._cpp_backend, even_layer._cpp_backend
+            )
+
+    def get_layer_info(self) -> str:
+        return self._cpp_backend.get_layer_info()
+
+    def get_layer_name(self) -> str:
+        return self._cpp_backend.get_layer_name()
+
+
+class Exp(BaseLayer):
+    """Exp"""
+
+    def __init__(self, scale: float = 1.0, shift: float = 0.0):
+        self._cpp_backend = cutagi.Exp(scale, shift)
+
+    def get_layer_info(self) -> str:
+        return self._cpp_backend.get_layer_info()
+
+    def get_layer_name(self) -> str:
+        return self._cpp_backend.get_layer_name()
+
+
+class AGVI(BaseLayer):
+    """AGVI (Approximate Gaussian Variance Inference)"""
+
+    def __init__(
+        self,
+        activation_layer: BaseLayer,
+        overfit_mu: bool = True,
+        agvi: bool = True,
+    ):
+        """
+        Initializes the AGVI layer.
+
+        Args:
+            activation_layer: The inner activation layer to be used.
+            overfit_mu: If true, uses a different Kalman gain for the mean delta
+                        to encourage the mean overfitting. Defaults to True.
+        """
+        self._cpp_backend = cutagi.AGVI(
+            activation_layer._cpp_backend, overfit_mu, agvi
+        )
 
     def get_layer_info(self) -> str:
         return self._cpp_backend.get_layer_info()

--- a/src/activation.cpp
+++ b/src/activation.cpp
@@ -471,32 +471,29 @@ void softmax_mean_var(std::vector<float> &mu_z, std::vector<float> &var_z,
     }
 }
 
-void even_exp_mean_var(std::vector<float> const &mu_z,
-                       std::vector<float> const &var_z,
-                       std::vector<float> &jcb_z, int start_chunk,
-                       int end_chunk, std::vector<float> &mu_a,
-                       std::vector<float> &var_a, std::vector<float> &jcb_a)
+void exp_mean_var(std::vector<float> const &mu_z,
+                  std::vector<float> const &var_z, std::vector<float> &jcb_z,
+                  int start_chunk, int end_chunk, std::vector<float> &mu_a,
+                  std::vector<float> &var_a, std::vector<float> &jcb_a,
+                  float scale, float shift)
 
 {
     for (int i = start_chunk; i < end_chunk; i++) {
-        if (i % 2 == 0) {
-            mu_a[i] = mu_z[i];
-            var_a[i] = var_z[i];
-            jcb_a[i] = jcb_z[i];
-        } else {
-            mu_a[i] = expf(mu_z[i] + 0.5 * var_z[i]);
-            var_a[i] = expf(2 * mu_z[i] + var_z[i]) * (expf(var_z[i]) - 1);
-            jcb_a[i] = var_z[i] * mu_a[i];
-        }
+        float new_mu = mu_z[i] * scale + shift;
+        float new_var = var_z[i] * scale * scale;
+
+        mu_a[i] = std::min(expf(new_mu + 0.5 * new_var), 1e-12f);
+        var_a[i] =
+            std::min(expf(2 * new_mu + new_var) * (expf(new_var) - 1), 1e-12f);
+        jcb_a[i] = std::min(mu_a[i] * scale, 1e-12f);
     }
 }
 
-void even_exp_mean_var_mp(std::vector<float> const &mu_z,
-                          std::vector<float> const &var_z,
-                          std::vector<float> &jcb_z, int n,
-                          unsigned int num_threads, std::vector<float> &mu_a,
-                          std::vector<float> &var_a,
-                          std::vector<float> &jcb_a) {
+void exp_mean_var_mp(std::vector<float> const &mu_z,
+                     std::vector<float> const &var_z, std::vector<float> &jcb_z,
+                     int n, unsigned int num_threads, std::vector<float> &mu_a,
+                     std::vector<float> &var_a, std::vector<float> &jcb_a,
+                     float scale, float shift) {
     std::vector<std::thread> threads;
     threads.reserve(num_threads);
 
@@ -509,8 +506,141 @@ void even_exp_mean_var_mp(std::vector<float> const &mu_z,
         int end_chunk = start_chunk + n_per_thread + (i < extra ? 1 : 0);
 
         threads.emplace_back([=, &mu_z, &var_z, &jcb_z, &mu_a, &var_a, &jcb_a] {
-            even_exp_mean_var(mu_z, var_z, jcb_z, start_chunk, end_chunk, mu_a,
-                              var_a, jcb_a);
+            exp_mean_var(mu_z, var_z, jcb_z, start_chunk, end_chunk, mu_a,
+                         var_a, jcb_a, scale, shift);
+        });
+    }
+
+    for (auto &thread : threads) {
+        if (thread.joinable()) {
+            thread.join();
+        }
+    }
+}
+
+void agvi_backward_chunk(int start_chunk, int end_chunk,
+                         BaseDeltaStates &input_delta_states,
+                         BaseDeltaStates &output_delta_states,
+                         const BaseHiddenStates &stored_output_states,
+                         const BaseHiddenStates &stored_inner_output_states,
+                         const BaseHiddenStates &stored_input_states,
+                         bool overfit_mu) {
+    /*
+     * Processes a chunk of the backward pass for the AGVI layer.
+     * This function is designed to be called by a single thread.
+     *
+     * @param start_chunk The starting index for the chunk.
+     * @param end_chunk The ending index for the chunk.
+     * @param input_delta_states Deltas from the subsequent layer.
+     * @param output_delta_states Deltas to be passed to the preceding layer.
+     * @param stored_output_states The output states from the forward pass.
+     * @param stored_inner_output_states The inner activation's output from the
+     * forward pass.
+     * @param stored_input_states The input states from the forward pass.
+     * @param overfit_mu Flag to control the Jacobian for the mean delta.
+     */
+    for (int i = start_chunk; i < end_chunk; i++) {
+        // 1. Retrieve stored values from the forward pass.
+        float mu_a = stored_output_states.mu_a[i];
+        float var_a = stored_output_states.var_a[i];
+
+        // V2_bar_tilde
+        float mu_v2_bar_tilde = stored_inner_output_states.mu_a[i];
+        float var_v2_bar_tilde = stored_inner_output_states.var_a[i];
+        float jcb_v2_bar_tilde = stored_inner_output_states.jcb[i];
+
+        // Deltas from the subsequent layer
+        float incoming_delta_mu = input_delta_states.delta_mu[i];
+        float incoming_delta_var = input_delta_states.delta_var[i];
+
+        // Prior variance for Z (from the even input stream)
+        float var_z = stored_input_states.var_a[i * 2];
+
+        // 2. Perform the backward message passing calculations.
+
+        // Compute the prior predictive PDF for v2
+        float mu_v2 = mu_v2_bar_tilde;
+        float var_v2 =
+            3.0f * var_v2_bar_tilde + 2.0f * mu_v2_bar_tilde * mu_v2_bar_tilde;
+
+        // V ~ N(0, mu_v2)
+        float mu_v = 0.0f;
+        float var_v = mu_v2;
+
+        // Compute the posterior mean and variance for A (output)
+        float mu_a_pos = mu_a + incoming_delta_mu * var_a;
+        float var_a_pos = var_a + incoming_delta_var * var_a * var_a;
+
+        // Compute the posterior mean and variance for V
+        float Jv = var_v / var_a;
+        float mu_v_pos = mu_v + Jv * (mu_a_pos - mu_a);
+        float var_v_pos = var_v + Jv * Jv * (var_a_pos - var_a);
+
+        // Compute the posterior mean and variance for V2
+        float mu_v2_pos = mu_v_pos * mu_v_pos + var_v_pos;
+        float var_v2_pos = 2.0f * var_v_pos * var_v_pos +
+                           4.0f * var_v_pos * mu_v_pos * mu_v_pos;
+
+        // Compute the posterior mean and variance for V2_bar_tilde
+        float Jv2_bar_tilde = var_v2_bar_tilde / var_v2;
+        float mu_v2_bar_tilde_pos =
+            mu_v2_bar_tilde + Jv2_bar_tilde * (mu_v2_pos - mu_v2);
+        float var_v2_bar_tilde_pos =
+            var_v2_bar_tilde +
+            Jv2_bar_tilde * Jv2_bar_tilde * (var_v2_pos - var_v2);
+
+        // 3. Define the output indices for the even (Z) and odd (V2_bar) stream
+        int even_idx = 2 * i;
+        int odd_idx = 2 * i + 1;
+
+        // 4. Compute and write deltas for V2_bar (the odd input stream).
+        float Jv2_bar = jcb_v2_bar_tilde / var_v2_bar_tilde;
+        output_delta_states.delta_mu[odd_idx] =
+            Jv2_bar * (mu_v2_bar_tilde_pos - mu_v2_bar_tilde);
+        output_delta_states.delta_var[odd_idx] =
+            Jv2_bar * Jv2_bar * (var_v2_bar_tilde_pos - var_v2_bar_tilde);
+
+        // --- MODIFIED ---
+        // 5. Compute and write deltas for Z (the even input stream).
+        float Jz = 1.0f / var_a;
+        float Jz_mu;
+        if (overfit_mu) {
+            // Use different J for the mean to allow overfitting on it
+            Jz_mu = 1.0f / var_z;
+        } else {
+            // Use the same J for the mean and variance
+            Jz_mu = Jz;
+        }
+        output_delta_states.delta_mu[even_idx] = Jz_mu * (mu_a_pos - mu_a);
+        output_delta_states.delta_var[even_idx] = Jz * Jz * (var_a_pos - var_a);
+    }
+}
+
+void agvi_backward_mp(int n, unsigned int num_threads,
+                      BaseDeltaStates &input_delta_states,
+                      BaseDeltaStates &output_delta_states,
+                      const BaseHiddenStates &stored_output_states,
+                      const BaseHiddenStates &stored_inner_output_states,
+                      const BaseHiddenStates &stored_input_states,
+                      bool overfit_mu) {
+    std::vector<std::thread> threads;
+    threads.reserve(num_threads);
+
+    int n_per_thread = n / num_threads;
+    int extra = n % num_threads;
+
+    for (unsigned int i = 0; i < num_threads; ++i) {
+        int start_chunk = i * n_per_thread + std::min(i, (unsigned int)extra);
+        int end_chunk = start_chunk + n_per_thread + (i < extra ? 1 : 0);
+
+        threads.emplace_back([=, &input_delta_states, &output_delta_states,
+                              &stored_output_states,
+                              &stored_inner_output_states,
+                              &stored_input_states] {
+            agvi_backward_chunk(start_chunk, end_chunk, input_delta_states,
+                                output_delta_states, stored_output_states,
+                                stored_inner_output_states, stored_input_states,
+                                overfit_mu);
         });
     }
 
@@ -1455,51 +1585,206 @@ std::unique_ptr<BaseLayer> ClosedFormSoftmax::to_cuda(int device_idx) {
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////
-/// EvenExp
+/// SplitActivation (formerly EvenExp)
 ////////////////////////////////////////////////////////////////////////////////
-EvenExp::EvenExp() {}
-EvenExp::~EvenExp() {}
 
-std::string EvenExp::get_layer_info() const
+SplitActivation::SplitActivation(std::shared_ptr<BaseLayer> odd_layer,
+                                 std::shared_ptr<BaseLayer> even_layer)
+    : odd_layer(odd_layer), even_layer(even_layer) {
+    if (!odd_layer) {
+        // It's crucial that the odd_layer exists.
+        // We could throw an exception here for robustness.
+        std::cerr << "Error: SplitActivation must be initialized with a valid "
+                     "layer for odd-indexed positions."
+                  << std::endl;
+    }
+}
+
+SplitActivation::~SplitActivation() {}
+
+std::string SplitActivation::get_layer_info() const {
+    std::string even_layer_name = "Identity";
+    if (even_layer) {
+        even_layer_name = even_layer->get_layer_name();
+    }
+    return "SplitActivation(odd=" + odd_layer->get_layer_name() +
+           ", even=" + even_layer_name + ")";
+}
+
+std::string SplitActivation::get_layer_name() const {
+    return "SplitActivation";
+}
+
+LayerType SplitActivation::get_layer_type() const {
+    return LayerType::Activation;
+}
+
+void SplitActivation::forward(BaseHiddenStates &input_states,
+                              BaseHiddenStates &output_states,
+                              BaseTempStates &temp_states) {
+    // 1. Calculate the total number of elements to process.
+    int total_elements = input_states.actual_size * input_states.block_size;
+    int odd_count = total_elements / 2;
+    int even_count = total_elements - odd_count;
+
+    // 2. Prepare temporary hidden states for the odd and even data streams.
+    BaseHiddenStates odd_input_states;
+    odd_input_states.mu_a.reserve(odd_count);
+    odd_input_states.var_a.reserve(odd_count);
+    odd_input_states.jcb.reserve(odd_count);
+
+    BaseHiddenStates even_input_states;
+    even_input_states.mu_a.reserve(even_count);
+    even_input_states.var_a.reserve(even_count);
+    even_input_states.jcb.reserve(even_count);
+
+    // 3. Split the input data into odd and even streams.
+    for (int i = 0; i < total_elements; ++i) {
+        if (i % 2 == 0) {  // Even indices
+            even_input_states.mu_a.push_back(input_states.mu_a[i]);
+            even_input_states.var_a.push_back(input_states.var_a[i]);
+            even_input_states.jcb.push_back(input_states.jcb[i]);
+        } else {  // Odd indices
+            odd_input_states.mu_a.push_back(input_states.mu_a[i]);
+            odd_input_states.var_a.push_back(input_states.var_a[i]);
+            odd_input_states.jcb.push_back(input_states.jcb[i]);
+        }
+    }
+
+    // Set metadata for the temporary states.
+    odd_input_states.block_size = input_states.block_size;
+    odd_input_states.actual_size = odd_count / input_states.block_size;
+    even_input_states.block_size = input_states.block_size;
+    even_input_states.actual_size = even_count / input_states.block_size;
+
+    // 4. Apply the activation layers to their respective streams.
+
+    // Process the odd stream using the mandatory odd_layer.
+    BaseHiddenStates odd_output_states;
+    odd_output_states.mu_a.resize(odd_count);
+    odd_output_states.var_a.resize(odd_count);
+    odd_output_states.jcb.resize(odd_count);
+    odd_layer->forward(odd_input_states, odd_output_states, temp_states);
+
+    // Process the even stream.
+    BaseHiddenStates even_output_states;
+    if (even_layer) {
+        // If an even_layer is provided, use it.
+        even_output_states.mu_a.resize(even_count);
+        even_output_states.var_a.resize(even_count);
+        even_output_states.jcb.resize(even_count);
+        even_layer->forward(even_input_states, even_output_states, temp_states);
+    } else {
+        // If no even_layer is provided, apply an identity transformation
+        // by moving the input states to the output states.
+        even_output_states = std::move(even_input_states);
+    }
+
+    // 5. Merge the processed streams back into the final output_states.
+    int odd_idx = 0;
+    int even_idx = 0;
+    for (int i = 0; i < total_elements; ++i) {
+        if (i % 2 == 0) {  // Even indices
+            output_states.mu_a[i] = even_output_states.mu_a[even_idx];
+            output_states.var_a[i] = even_output_states.var_a[even_idx];
+            output_states.jcb[i] = even_output_states.jcb[even_idx];
+            even_idx++;
+        } else {  // Odd indices
+            output_states.mu_a[i] = odd_output_states.mu_a[odd_idx];
+            output_states.var_a[i] = odd_output_states.var_a[odd_idx];
+            output_states.jcb[i] = odd_output_states.jcb[odd_idx];
+            odd_idx++;
+        }
+    }
+
+    // 6. Update layer and output_states metadata to match the input.
+    this->input_size = input_states.actual_size;
+    this->output_size = input_states.actual_size;
+
+    output_states.size = input_states.size;
+    output_states.block_size = input_states.block_size;
+    output_states.actual_size = input_states.actual_size;
+}
+
+void SplitActivation::save(std::ofstream &file) {
+    // Save the state of the inner layers.
+    if (odd_layer) {
+        odd_layer->save(file);
+    }
+    if (even_layer) {
+        even_layer->save(file);
+    }
+}
+
+void SplitActivation::load(std::ifstream &file) {
+    // Load the state of the inner layers.
+    if (odd_layer) {
+        odd_layer->load(file);
+    }
+    if (even_layer) {
+        even_layer->load(file);
+    }
+}
+
+#ifdef USE_CUDA
+std::unique_ptr<BaseLayer> SplitActivation::to_cuda(int device_idx) {
+    this->device = "cuda";
+    // Convert inner layers to their CUDA equivalents.
+    auto cuda_odd_layer = odd_layer->to_cuda(device_idx);
+    std::unique_ptr<BaseLayer> cuda_even_layer = nullptr;
+    if (even_layer) {
+        cuda_even_layer = even_layer->to_cuda(device_idx);
+    }
+    // Note: This assumes a SplitActivationCuda class exists.
+    return std::make_unique<SplitActivationCuda>(std::move(cuda_odd_layer),
+                                                 std::move(cuda_even_layer));
+    // return nullptr; // Placeholder until SplitActivationCuda is implemented
+}
+#endif
+
+////////////////////////////////////////////////////////////////////////////////
+/// Exp
+////////////////////////////////////////////////////////////////////////////////
+Exp::Exp(float scale, float shift) : scale(scale), shift(shift) {}
+Exp::~Exp() {}
+
+std::string Exp::get_layer_info() const
 /*
  */
 {
-    return "EvenExp()";
+    return "Exp()";
 }
 
-std::string EvenExp::get_layer_name() const
+std::string Exp::get_layer_name() const
 /*
  */
 
 {
-    return "EvenExp";
+    return "Exp";
 }
 
-LayerType EvenExp::get_layer_type() const
+LayerType Exp::get_layer_type() const
 /*
  */
 {
     return LayerType::Activation;
 }
 
-void EvenExp::forward(BaseHiddenStates &input_states,
-                      BaseHiddenStates &output_states,
-                      BaseTempStates &temp_states)
+void Exp::forward(BaseHiddenStates &input_states,
+                  BaseHiddenStates &output_states, BaseTempStates &temp_states)
 /*
  */
 {
     int start_chunk = 0;
     int end_chunk = input_states.actual_size * input_states.block_size;
     if (this->num_threads > 1) {
-        even_exp_mean_var_mp(input_states.mu_a, input_states.var_a,
-                             input_states.jcb, end_chunk, this->num_threads,
-                             output_states.mu_a, output_states.var_a,
-                             output_states.jcb);
+        exp_mean_var_mp(input_states.mu_a, input_states.var_a, input_states.jcb,
+                        end_chunk, this->num_threads, output_states.mu_a,
+                        output_states.var_a, output_states.jcb, scale, shift);
     } else {
-        even_exp_mean_var(input_states.mu_a, input_states.var_a,
-                          input_states.jcb, start_chunk, end_chunk,
-                          output_states.mu_a, output_states.var_a,
-                          output_states.jcb);
+        exp_mean_var(input_states.mu_a, input_states.var_a, input_states.jcb,
+                     start_chunk, end_chunk, output_states.mu_a,
+                     output_states.var_a, output_states.jcb, scale, shift);
     }
 
     this->input_size = input_states.actual_size;
@@ -1512,8 +1797,163 @@ void EvenExp::forward(BaseHiddenStates &input_states,
 }
 
 #ifdef USE_CUDA
-std::unique_ptr<BaseLayer> EvenExp::to_cuda(int device_idx) {
+std::unique_ptr<BaseLayer> Exp::to_cuda(int device_idx) {
     this->device = "cuda";
-    return std::make_unique<EvenExpCuda>();
+    return std::make_unique<ExpCuda>(scale, shift);
+}
+#endif
+
+////////////////////////////////////////////////////////////////////////////////
+/// AGVI (Approximate Gaussian Variance Inference)
+////////////////////////////////////////////////////////////////////////////////
+AGVI::AGVI(std::shared_ptr<BaseLayer> activation_layer, bool overfit_mu,
+           bool agvi)
+    : m_activation_layer(activation_layer),
+      m_overfit_mu(overfit_mu),
+      m_agvi(agvi) {
+    if (!m_activation_layer ||
+        m_activation_layer->get_layer_type() != LayerType::Activation) {
+        std::cerr << "Error: AGVI layer must be initialized with a valid "
+                     "activation layer."
+                  << std::endl;
+        m_activation_layer = std::make_shared<ReLU>();
+    }
+}
+
+AGVI::~AGVI() {}
+
+std::string AGVI::get_layer_info() const {
+    return "AGVI(" + m_activation_layer->get_layer_name() + ")";
+}
+
+std::string AGVI::get_layer_name() const { return "AGVI"; }
+
+LayerType AGVI::get_layer_type() const { return LayerType::AGVI; }
+
+void AGVI::forward(BaseHiddenStates &input_states,
+                   BaseHiddenStates &output_states,
+                   BaseTempStates &temp_states) {
+    // The AGVI layer's logic is a wrapper for another activation function.
+    // 1. Take odd-indexed positions from the input.
+    // 2. Pass them through the inner activation function.
+    // 3. Take the output mean of the inner activation and add it to the
+    //    variance of the corresponding even-indexed position of the input.
+    // 4. The output of the AGVI layer is only the even-indexed positions.
+
+    int total_elements = input_states.actual_size * input_states.block_size;
+    int odd_count = total_elements / 2;
+    int even_count = total_elements / 2;
+
+    // The output size is halved as we only propagate the even stream.
+    output_states.block_size = input_states.block_size;
+    output_states.actual_size = input_states.actual_size / 2;
+    output_states.size = input_states.size;
+
+    // Prepare temporary vectors for odd positions
+    std::vector<float> odd_mu, odd_var, odd_jcb;
+    odd_mu.reserve(odd_count);
+    odd_var.reserve(odd_count);
+    odd_jcb.reserve(odd_count);
+
+    // Copy odd-indexed elements to a temporary state
+    for (int i = 0; i < total_elements; ++i) {
+        if (i % 2 != 0) {  // Check for odd positions
+            odd_mu.push_back(input_states.mu_a[i]);
+            odd_var.push_back(input_states.var_a[i]);
+            odd_jcb.push_back(input_states.jcb[i]);
+        }
+    }
+
+    // Create temporary BaseHiddenStates for the inner activation layer
+    BaseHiddenStates odd_input_states;
+    odd_input_states.mu_a = std::move(odd_mu);
+    odd_input_states.var_a = std::move(odd_var);
+    odd_input_states.jcb = std::move(odd_jcb);
+    odd_input_states.actual_size = odd_count / input_states.block_size;
+    odd_input_states.block_size = input_states.block_size;
+
+    // Create temporary BaseHiddenStates for the output of the inner layer
+    BaseHiddenStates odd_output_states;
+    odd_output_states.mu_a.resize(odd_count);
+    odd_output_states.var_a.resize(odd_count);
+    odd_output_states.jcb.resize(odd_count);
+
+    // Call the forward pass of the inner activation layer on the odd positions
+    m_activation_layer->forward(odd_input_states, odd_output_states,
+                                temp_states);
+
+    // Store the output of the inner layer for use in the backward pass.
+    m_stored_inner_output_states = odd_output_states;
+
+    int even_pos_idx = 0;
+    for (int i = 0; i < total_elements; ++i) {
+        if (i % 2 == 0) {  // Check for even positions
+            output_states.mu_a[even_pos_idx] = input_states.mu_a[i];
+            output_states.jcb[even_pos_idx] = input_states.jcb[i];
+            // The output variance is the input variance
+            // + the mean of the corresponding odd position
+            if (m_agvi) {
+                output_states.var_a[even_pos_idx] =
+                    input_states.var_a[i] +
+                    m_stored_inner_output_states.mu_a[even_pos_idx];
+            } else {
+                output_states.var_a[even_pos_idx] = input_states.var_a[i];
+            }
+            even_pos_idx++;
+        }
+    }
+
+    // Store states for backward pass
+    m_stored_output_states = output_states;
+    m_stored_input_states = input_states;
+
+    // Update layer input and output sizes
+    this->input_size = input_states.actual_size;
+    this->output_size = output_states.actual_size;
+}
+
+void AGVI::backward(BaseDeltaStates &input_delta_states,
+                    BaseDeltaStates &output_delta_states,
+                    BaseTempStates &temp_states, bool state_update) {
+    int total_output_size = this->output_size * input_delta_states.block_size;
+
+    // Decide whether to use multiprocessing
+    if (this->num_threads > 1) {
+        agvi_backward_mp(total_output_size, this->num_threads,
+                         input_delta_states, output_delta_states,
+                         m_stored_output_states, m_stored_inner_output_states,
+                         m_stored_input_states, m_overfit_mu);
+    } else {
+        agvi_backward_chunk(0, total_output_size, input_delta_states,
+                            output_delta_states, m_stored_output_states,
+                            m_stored_inner_output_states, m_stored_input_states,
+                            m_overfit_mu);
+    }
+
+    // Remove the stored states after the backward pass is complete to free
+    // memory.
+    m_stored_inner_output_states.mu_a.clear();
+    m_stored_inner_output_states.var_a.clear();
+    m_stored_inner_output_states.jcb.clear();
+    m_stored_output_states.mu_a.clear();
+    m_stored_output_states.var_a.clear();
+    m_stored_output_states.jcb.clear();
+    m_stored_input_states.mu_a.clear();
+    m_stored_input_states.var_a.clear();
+    m_stored_input_states.jcb.clear();
+
+    // The output deltas now have the same full size as the original input to
+    // this layer.
+    output_delta_states.actual_size = this->input_size;
+    output_delta_states.block_size = input_delta_states.block_size;
+    output_delta_states.size = input_delta_states.size;
+}
+
+#ifdef USE_CUDA
+std::unique_ptr<BaseLayer> AGVI::to_cuda(int device_idx) {
+    this->device = "cuda";
+    auto cuda_inner_layer = m_activation_layer->to_cuda(device_idx);
+    return std::make_unique<AGVICuda>(std::move(cuda_inner_layer), m_overfit_mu,
+                                      m_agvi);
 }
 #endif

--- a/src/activation.cpp
+++ b/src/activation.cpp
@@ -482,10 +482,9 @@ void exp_mean_var(std::vector<float> const &mu_z,
         float new_mu = mu_z[i] * scale + shift;
         float new_var = var_z[i] * scale * scale;
 
-        mu_a[i] = std::min(expf(new_mu + 0.5 * new_var), 1e-12f);
-        var_a[i] =
-            std::min(expf(2 * new_mu + new_var) * (expf(new_var) - 1), 1e-12f);
-        jcb_a[i] = std::min(mu_a[i] * scale, 1e-12f);
+        mu_a[i] = expf(new_mu + 0.5 * new_var);
+        var_a[i] = expf(2 * new_mu + new_var) * (expf(new_var) - 1);
+        jcb_a[i] = mu_a[i] * scale;
     }
 }
 

--- a/src/activation_cuda.cu
+++ b/src/activation_cuda.cu
@@ -170,30 +170,108 @@ __global__ void mixture_sigmoid_mean_var_cuda(float const *mu_z,
     if (col < num_states) {
         // cdf and pdf for truncated normal distribution
         std_z = powf(var_z[col], 0.5);
-        alpha_l = (1.0f + mu_z[col]) / std_z;  // Lower truncation
-        alpha_u = (1.0f - mu_z[col]) / std_z;  // Upper truncation
+        alpha_l =
+            (1.0f + (mu_z[col] * 2.0f - 1.0f)) / std_z;  // Lower truncation
+        alpha_u =
+            (1.0f - (mu_z[col] * 2.0f - 1.0f)) / std_z;  // Upper truncation
         cdf_l = normcdf_cuda(alpha_l);
         cdf_u = normcdf_cuda(alpha_u);
         pdf_l = (1.0f / SQRT_2PI) * expf(-0.5f * alpha_l * alpha_l);
         pdf_u = (1.0f / SQRT_2PI) * expf(-0.5f * alpha_u * alpha_u);
 
         // Moments calculations (L. Alric, 2024)
-        float tmp_mu_z = mu_z[col];
+        float tmp_mu_z = mu_z[col] * 2.0f - 1.0f;
         float tmp_mu_z_2 = tmp_mu_z * tmp_mu_z;
         float tmp_mu_a = (tmp_mu_z + 1) * cdf_l + (tmp_mu_z - 1) * cdf_u +
                          std_z * (pdf_l - pdf_u) - tmp_mu_z;
 
-        mu_a[col] = fmaxf(0.0000001f, tmp_mu_a);
+        mu_a[col] = tmp_mu_a;
         var_a[col] =
-            max(0.0000001f,
-                (cdf_l * (var_z[col] - tmp_mu_z_2 - 2 * tmp_mu_z - 1) +
-                 cdf_u * (var_z[col] - tmp_mu_z_2 + 2 * tmp_mu_z - 1) +
-                 std_z * (pdf_u * (tmp_mu_z - 1) - pdf_l * (tmp_mu_z + 1)) -
-                 tmp_mu_a * tmp_mu_a + 2 * mu_a[col] * tmp_mu_z +
-                 tmp_mu_z * tmp_mu_z - var_z[col] + 2) /
-                    4.0f);
-        mu_a[col] = tmp_mu_a / 2.0f + 0.5f;
+            fmaxf(0.0000001f,
+                  (cdf_l * (var_z[col] - tmp_mu_z_2 - 2 * tmp_mu_z - 1) +
+                   cdf_u * (var_z[col] - tmp_mu_z_2 + 2 * tmp_mu_z - 1) +
+                   std_z * (pdf_u * (tmp_mu_z - 1) - pdf_l * (tmp_mu_z + 1)) -
+                   tmp_mu_a * tmp_mu_a + 2 * mu_a[col] * tmp_mu_z +
+                   tmp_mu_z * tmp_mu_z - var_z[col] + 2) /
+                      4.0f);
+        mu_a[col] = fmaxf(tmp_mu_a / 2.0f + 0.5f, 0.0000001f);
         jcb[col] = (cdf_u + cdf_l - 1) / 2.0f;
+    }
+
+    // // Double sided mReLU
+    // int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    // float lower_bound = 0.0f;
+    // float upper_bound = 1.0f;
+    // constexpr float INV_SQRT_2 = 0.7071067811865475f;
+    // constexpr float TINY_FLOAT = 0.0000001f;
+
+    // if (idx < num_states) {
+    //     // Load input mean and variance for the current element
+    //     float mu_y_i = mu_z[idx];
+    //     float var_y_i = var_z[idx];
+    //     float sigma_y_i = sqrtf(fmaxf(var_y_i, TINY_FLOAT));
+
+    //     // Standardize the bounds
+    //     float alpha = (lower_bound - mu_y_i) / sigma_y_i; // Corresponds to
+    //     z_lower float beta = (upper_bound - mu_y_i) / sigma_y_i;   //
+    //     Corresponds to z_upper
+
+    //     // Compute PDF and CDF values
+    //     float cdf_alpha = normcdf_cuda(alpha);
+    //     float cdf_beta = normcdf_cuda(beta);
+    //     float pdf_alpha = normpdf_cuda(alpha);
+    //     float pdf_beta = normpdf_cuda(beta);
+
+    //     float cdf_diff = cdf_beta - cdf_alpha;
+
+    //     // ---- 1. Calculate Mean E[z] ----
+    //     float tmp_mu_z = lower_bound * cdf_alpha +
+    //                      mu_y_i * cdf_diff +
+    //                      sigma_y_i * (pdf_alpha - pdf_beta) +
+    //                      upper_bound * (1.0f - cdf_beta);
+
+    //     // ---- 2. Calculate Second Moment E[z^2] ----
+    //     float term1_Ez2 = lower_bound * lower_bound * cdf_alpha;
+    //     float term2_Ez2 = (mu_y_i * mu_y_i + var_y_i) * cdf_diff;
+    //     float term3_Ez2 = -sigma_y_i * ((mu_y_i + upper_bound) * pdf_beta -
+    //     (mu_y_i + lower_bound) * pdf_alpha); float term4_Ez2 = upper_bound *
+    //     upper_bound * (1.0f - cdf_beta); float Ez2 = term1_Ez2 + term2_Ez2 +
+    //     term3_Ez2 + term4_Ez2;
+
+    //     // ---- 3. Calculate Variance Var[z] ----
+    //     float tmp_var_z = Ez2 - tmp_mu_z * tmp_mu_z;
+
+    //     // ---- 4. Calculate Cross Moment E[y*z] to find Cov(y, z) ----
+    //     float term1_Eyz = lower_bound * (mu_y_i * cdf_alpha - sigma_y_i *
+    //     pdf_alpha);
+    //     // term2_Eyz is identical to term2_Ez2
+    //     // term3_Eyz is identical to term3_Ez2
+    //     float term4_Eyz = upper_bound * (mu_y_i * (1.0f - cdf_beta) +
+    //     sigma_y_i * pdf_beta); float Eyz = term1_Eyz + term2_Ez2 + term3_Ez2
+    //     + term4_Eyz;
+
+    //     float cov_yz = Eyz - tmp_mu_z * mu_y_i;
+
+    //     // Store the final results
+    //     mu_a[idx] = fmaxf(tmp_mu_z, TINY_FLOAT);
+    //     var_a[idx] = fmaxf(tmp_var_z, TINY_FLOAT);
+    //     jcb[idx] = cov_yz / fmaxf(var_y_i, TINY_FLOAT);
+    // }
+}
+
+__global__ void normalize_means(float *mu_a, float *var_a, float *jcb,
+                                int num_states, int batch_size) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < batch_size) {
+        float sum = 0.0f;
+        for (int j = 0; j < num_states; j++) {
+            sum += mu_a[j + idx * num_states];
+        }
+        for (int j = 0; j < num_states; j++) {
+            mu_a[j + idx * num_states] /= sum;
+            var_a[j + idx * num_states] /= (sum * sum);
+            jcb[j + idx * num_states] /= sum;
+        }
     }
 }
 
@@ -337,10 +415,17 @@ __global__ void softplus_mean_var_cuda(float const *mu_z, float const *var_z,
     int col = blockIdx.x * blockDim.x + threadIdx.x;
     float tmp = 0;
     if (col < num_states) {
-        mu_a[col] = logf(1 + expf(mu_z[col]));
-        tmp = 1 / (1 + expf(-mu_z[col]));
-        jcb[col] = tmp;
-        var_a[col] = tmp * var_z[col] * tmp;
+        float lambda = 0.1f;
+        if (mu_z[col] > lambda) {
+            mu_a[col] = lambda;
+            jcb[col] = -0.001f;
+            var_a[col] = 0.001f;
+        } else {
+            mu_a[col] = fmaxf(logf(1 + expf(mu_z[col])), 0.000001f);
+            tmp = 1 / (1 + expf(-mu_z[col]));
+            jcb[col] = tmp;
+            var_a[col] = fmaxf(tmp * var_z[col] * tmp, 0.000001f);
+        }
     }
 }
 
@@ -607,18 +692,23 @@ __global__ void exp_mean_var_cuda(float const *mu_z, float const *var_z,
         float new_mu_z = mu_z[col] * scale + shift;
 
         // Calculate the output mean using the constrained new_mu_z
-        mu_a[col] = fmaxf(expf(new_mu_z + 0.5f * new_var_z), 0.0001f);
+        mu_a[col] = fmaxf(expf(new_mu_z + 0.5f * new_var_z), 0.0000001f);
 
         // Calculate the output variance using the constrained new_mu_z
         var_a[col] =
             fmaxf(expf(2.0f * new_mu_z + new_var_z) * (expf(new_var_z) - 1.0f),
-                  0.0001f);
+                  0.0000001f);
 
         // Calculate the Jacobian based on the constrained new_mu_z
         jcb_a[col] = mu_a[col] * scale;
     }
 }
 
+/**
+ * @brief Extracts the odd-indexed elements from a full input stream.
+ * * Each thread 'i' computes the source index as 2*i + 1 and copies the data.
+ * This prepares the input for the aleatoric uncertainty branch (odd stream).
+ */
 __global__ void agvi_extract_odd_stream_kernel(
     const float *d_input_mu, const float *d_input_var, const float *d_input_jcb,
     int half_size, float *d_odd_mu, float *d_odd_var, float *d_odd_jcb) {
@@ -631,25 +721,27 @@ __global__ void agvi_extract_odd_stream_kernel(
     }
 }
 
-__global__ void agvi_forward_combine_kernel(
-    const float *d_input_mu, const float *d_input_var, const float *d_input_jcb,
-    const float *d_inner_output_mu, int half_size, float *d_output_mu,
-    float *d_output_var, float *d_output_jcb, bool agvi) {
+__global__ void agvi_forward_combine_kernel(const float *d_even_stream_mu,
+                                            const float *d_even_stream_var,
+                                            const float *d_inner_output_mu,
+                                            int half_size, float *d_output_mu,
+                                            float *d_output_var,
+                                            float *d_output_jcb, bool agvi) {
     int i = blockIdx.x * blockDim.x + threadIdx.x;
     if (i < half_size) {
-        int even_input_idx = 2 * i;
-        d_output_mu[i] = d_input_mu[even_input_idx];
-        d_output_jcb[i] = d_input_jcb[even_input_idx];
-        if (agvi)
-            d_output_var[i] =
-                d_input_var[even_input_idx] + d_inner_output_mu[i];
-        else
-            d_output_var[i] = d_input_var[even_input_idx];
+        // Output mean comes from the even stream (epistemic part)
+        d_output_mu[i] = d_even_stream_mu[i];
 
-        // printf("mu_out[%d]=%f, var_out[%d]=%f, epistemic_var=%f,
-        // aleatoric_var=%f\n",
-        //     i, d_output_mu[i], i, d_output_var[i],
-        //     d_input_var[even_input_idx], d_inner_output_mu[i]);
+        // The Jacobian of the output of this layer with respect to the even
+        // stream is 1.
+        d_output_jcb[i] = 1.0f;
+
+        // If AGVI is enabled, add the learned aleatoric variance
+        if (agvi) {
+            d_output_var[i] = d_even_stream_var[i] + d_inner_output_mu[i];
+        } else {
+            d_output_var[i] = d_even_stream_var[i];
+        }
     }
 }
 
@@ -657,84 +749,92 @@ __global__ void agvi_backward_kernel(
     const float *d_incoming_delta_mu, const float *d_incoming_delta_var,
     const float *d_stored_output_mu_a, const float *d_stored_output_var_a,
     const float *d_stored_inner_mu_a, const float *d_stored_inner_var_a,
-    const float *d_stored_inner_jcb, const float *d_stored_input_var_a,
-    int half_size, float *d_output_delta_mu, float *d_output_delta_var,
-    bool overfit_mu) {
+    const float *d_stored_inner_jcb, const float *d_stored_even_var_a,
+    const float *d_stored_even_jcb, int half_size, float *d_output_delta_mu,
+    float *d_output_delta_var, bool overfit_mu, bool has_even_layer) {
+    const float epsilon = 1.0e-6f;
     int i = blockIdx.x * blockDim.x + threadIdx.x;
 
-    const float epsilon = 0.0f;
-
     if (i < half_size) {
-        float mu_a = d_stored_output_mu_a[i];
-        float var_a = fmaxf(d_stored_output_var_a[i], epsilon);
+        // --- 1. Load stored values from forward pass ---
+        float var_zv =
+            fmaxf(d_stored_output_var_a[i], epsilon);  // Total variance of Z+V
+        float var_z = fmaxf(d_stored_even_var_a[i],
+                            epsilon);  // Epistemic variance from even stream
 
+        // Outputs of the inner (odd stream) activation
         float mu_v2_bar_tilde = d_stored_inner_mu_a[i];
-        float var_v2_bar_tilde = d_stored_inner_var_a[i];
+        float var_v2_bar_tilde = fmaxf(d_stored_inner_var_a[i], epsilon);
         float jcb_v2_bar_tilde = d_stored_inner_jcb[i];
 
         float incoming_delta_mu = d_incoming_delta_mu[i];
         float incoming_delta_var = d_incoming_delta_var[i];
 
-        float var_z = d_stored_input_var_a[i * 2];
-
+        // --- 2. Backward pass for the ODD stream (aleatoric part) ---
+        // Prior moments for v^2 (aleatoric variance)
         float mu_v2 = mu_v2_bar_tilde;
-        float var_v2 =
-            3.0f * var_v2_bar_tilde + 2.0f * mu_v2_bar_tilde * mu_v2_bar_tilde;
+        float var_v2 = fmaxf(
+            3.0f * var_v2_bar_tilde + 2.0f * mu_v2_bar_tilde * mu_v2_bar_tilde,
+            epsilon);
 
-        float mu_v = 0;
-        float var_v = fmaxf(mu_v2, epsilon);
+        // Moments for the noise term V ~ N(0, mu_v2)
+        float var_v = mu_v2;
 
+        // Posterior moments for V after observing the output
         float mu_v_pos = var_v * incoming_delta_mu;
-        float var_v_pos = var_v + var_v * incoming_delta_var * var_v;
+        float var_v_pos =
+            fmaxf(var_v + var_v * incoming_delta_var * var_v, epsilon);
 
+        // Posterior moments for V^2
         float mu_v2_pos = mu_v_pos * mu_v_pos + var_v_pos;
         float var_v2_pos = 2.0f * var_v_pos * var_v_pos +
                            4.0f * var_v_pos * mu_v_pos * mu_v_pos;
 
-        float Jv2_bar_tilde = var_v2_bar_tilde / fmaxf(var_v2, epsilon);
+        // Propagate updates back to V2_bar_tilde (pre-activation aleatoric
+        // variance)
+        float Jv2_bar_tilde = var_v2_bar_tilde / var_v2;
         float mu_v2_bar_tilde_pos =
             mu_v2_bar_tilde + Jv2_bar_tilde * (mu_v2_pos - mu_v2);
         float var_v2_bar_tilde_pos =
             var_v2_bar_tilde +
             Jv2_bar_tilde * Jv2_bar_tilde * (var_v2_pos - var_v2);
 
-        int even_idx = 2 * i;
-        int odd_idx = 2 * i + 1;
-
-        float Jv2_bar = jcb_v2_bar_tilde / fmaxf(var_v2_bar_tilde, epsilon);
-
+        // Final delta for the odd stream input
+        float Jv2_bar = jcb_v2_bar_tilde / var_v2_bar_tilde;
         float odd_delta_mu = Jv2_bar * (mu_v2_bar_tilde_pos - mu_v2_bar_tilde);
         float odd_delta_var =
             Jv2_bar * Jv2_bar * (var_v2_bar_tilde_pos - var_v2_bar_tilde);
 
-        if (isnan(odd_delta_mu) || isinf(odd_delta_mu) ||
-            isnan(odd_delta_var) || isinf(odd_delta_var)) {
-            odd_delta_mu = 0.0f;
-            odd_delta_var = 0.0f;
-        }
+        int odd_idx = 2 * i + 1;
+        d_output_delta_mu[odd_idx] =
+            (isnan(odd_delta_mu) || isinf(odd_delta_mu)) ? 0.0f : odd_delta_mu;
+        d_output_delta_var[odd_idx] =
+            (isnan(odd_delta_var) || isinf(odd_delta_var)) ? 0.0f
+                                                           : odd_delta_var;
 
-        d_output_delta_mu[odd_idx] = odd_delta_mu;
-        d_output_delta_var[odd_idx] = odd_delta_var;
+        float mu_zv_pos = var_zv * incoming_delta_mu;
+        float var_zv_pos = var_zv * incoming_delta_var * var_zv;
 
-        float Jz = 1.0f;
-        float Jz_mu;
+        // --- 3. Backward pass for the EVEN stream (epistemic part) ---
+        float Jz = has_even_layer ? d_stored_even_jcb[i] : 1.0f;
+
+        float even_delta_mu = Jz / var_zv * incoming_delta_mu;
+        // Kalman gain for the variance delta
+        float even_delta_var = Jz / var_zv * (var_zv_pos)*Jz / var_zv;
+
+        // Kalman gain for the mean delta
         if (overfit_mu) {
-            Jz_mu = var_a / (var_z);
-        } else {
-            Jz_mu = Jz;
+            // Use epistemic variance only, for a more direct update to the mean
+            even_delta_mu = Jz / var_z * (mu_zv_pos);
         }
 
-        float even_delta_mu = Jz_mu * incoming_delta_mu;
-        float even_delta_var = Jz * Jz * incoming_delta_var;
-
-        if (isnan(even_delta_mu) || isinf(even_delta_mu) ||
-            isnan(even_delta_var) || isinf(even_delta_var)) {
-            even_delta_mu = 0.0f;
-            even_delta_var = 0.0f;
-        }
-
-        d_output_delta_mu[even_idx] = even_delta_mu;
-        d_output_delta_var[even_idx] = even_delta_var;
+        int even_idx = 2 * i;
+        d_output_delta_mu[even_idx] =
+            (isnan(even_delta_mu) || isinf(even_delta_mu)) ? 0.0f
+                                                           : even_delta_mu;
+        d_output_delta_var[even_idx] =
+            (isnan(even_delta_var) || isinf(even_delta_var)) ? 0.0f
+                                                             : even_delta_var;
     }
 }
 
@@ -1495,28 +1595,82 @@ void RemaxCuda::forward(BaseHiddenStates &input_states,
 
     int batch_size = input_states.block_size;
     int hidden_size = input_states.actual_size;
+
+    // We calculate stats for only the first item in the batch for debugging.
+    int num_states_to_stat = hidden_size;
+
+    // --- 1. Get statistics using loops (debugging only) ---
+    if (num_states_to_stat > 0) {
+        // Step A: Create host vectors to hold the data from the GPU.
+        std::vector<float> host_mu_a(num_states_to_stat);
+        std::vector<float> host_var_a(num_states_to_stat);
+
+        // Step B: Copy the data from the GPU device to the CPU host.
+        cudaMemcpy(host_mu_a.data(), cu_input_states->d_mu_a,
+                   num_states_to_stat * sizeof(float), cudaMemcpyDeviceToHost);
+        cudaMemcpy(host_var_a.data(), cu_input_states->d_var_a,
+                   num_states_to_stat * sizeof(float), cudaMemcpyDeviceToHost);
+
+        // Step C: Now that the data is on the CPU, use standard loops.
+        // This code is copied from your Remax::forward CPU version.
+        float sum_mu_z = 0.0f;
+        for (float n : host_mu_a) {
+            sum_mu_z += n;
+        }
+        float mean_mu_z = sum_mu_z / num_states_to_stat;
+
+        float sum_var_z = 0.0f;
+        for (float n : host_var_a) {
+            sum_var_z += n;
+        }
+        float mean_var_z = sum_var_z / num_states_to_stat;
+
+        float std_mu_z = 0.0f;
+        float std_var_z = 0.0f;
+        for (int i = 0; i < num_states_to_stat; i++) {
+            std_mu_z += (host_mu_a[i] - mean_mu_z) * (host_mu_a[i] - mean_mu_z);
+            std_var_z +=
+                (host_var_a[i] - mean_var_z) * (host_var_a[i] - mean_var_z);
+        }
+        std_mu_z = sqrtf(std_mu_z / num_states_to_stat);
+        std_var_z = sqrtf(std_var_z / num_states_to_stat);
+
+        float min_mu_z = *std::min_element(host_mu_a.begin(), host_mu_a.end());
+        float max_mu_z = *std::max_element(host_mu_a.begin(), host_mu_a.end());
+
+        // Step D: Print the statistics.
+        std::cout << "RemaxCuda layer (Debug Stats): mean_mu_z = " << mean_mu_z
+                  << ", std_mu_z = " << std_mu_z
+                  << ", mean_var_z = " << mean_var_z
+                  << ", std_var_z = " << std_var_z << std::endl;
+
+        std::cout << "RemaxCuda layer (Debug Stats): min_mu_z = " << min_mu_z
+                  << ", max_mu_z = " << max_mu_z << std::endl;
+    }
+    // --- End of statistics calculation ---
+
+    int total_num_states = batch_size * hidden_size;
     if (this->batch_size_ != batch_size) {
         this->batch_size_ = batch_size;
         this->deallocate_memory();
         this->allocate_memory(hidden_size, batch_size);
     }
-    int num_states = batch_size * hidden_size;
+
     constexpr int THREADS = 256;
     constexpr int THREADS_BATCH = 16;
     constexpr int THREADS_HIDDEN = 16;
-    unsigned int blocks = (num_states + THREADS - 1) / THREADS;
+    unsigned int blocks = (total_num_states + THREADS - 1) / THREADS;
 
     mixture_relu_mean_var_cuda<<<blocks, THREADS>>>(
-        cu_input_states->d_mu_a, cu_input_states->d_var_a, num_states,
+        cu_input_states->d_mu_a, cu_input_states->d_var_a, total_num_states,
         this->d_mu_m, this->d_jcb_m, this->d_var_m);
 
-    // Compute mean and variance of Mt
+    // ... (rest of the function remains the same)
     unsigned int blocks_sum = (batch_size + THREADS - 1) / THREADS;
     compute_mean_var_sum_cuda<<<blocks_sum, THREADS>>>(
         this->d_mu_m, this->d_var_m, hidden_size, batch_size, this->d_mu_mt,
         this->d_var_mt);
 
-    // Compute mean and variance of log(M)
     unsigned int hidden_blocks =
         (hidden_size + THREADS_HIDDEN - 1) / THREADS_HIDDEN;
     unsigned int batch_blocks =
@@ -1528,7 +1682,6 @@ void RemaxCuda::forward(BaseHiddenStates &input_states,
         this->d_mu_m, this->d_var_m, hidden_size, batch_size, this->d_mu_log_m,
         this->d_var_log_m);
 
-    // Compute mean and variance of log(Mt)
     unsigned int blocks_log_mt = (batch_size + THREADS - 1) / THREADS;
     dim3 dim_grid_log_mt(1, blocks_log_mt);
     dim3 dim_block_log_mt(1, THREADS);
@@ -1536,18 +1689,15 @@ void RemaxCuda::forward(BaseHiddenStates &input_states,
         this->d_mu_mt, this->d_var_mt, 1, batch_size, this->d_mu_log_mt,
         this->d_var_log_mt);
 
-    // Compute covariance of log(M) and log(Mt)
     compute_cov_log_m_mt_cuda<<<dim_grid_log, dim_block_log>>>(
         this->d_mu_m, this->d_var_m, this->d_mu_mt, hidden_size, batch_size,
         this->d_cov_log_m_mt);
 
-    // Compute mean and variance of A
     compute_remax_mean_var_cuda<<<blocks_sum, THREADS>>>(
         this->d_mu_log_m, this->d_var_log_m, this->d_mu_log_mt,
         this->d_var_log_mt, this->d_cov_log_m_mt, hidden_size, batch_size,
         cu_output_states->d_mu_a, cu_output_states->d_var_a);
 
-    // Compute covariance of A and Z i.e., Jacobian.
     compute_cov_a_z_cuda<<<dim_grid_log, dim_block_log>>>(
         cu_output_states->d_mu_a, cu_output_states->d_var_a,
         cu_input_states->d_var_a, this->d_mu_m, this->d_var_m,
@@ -2195,16 +2345,24 @@ std::unique_ptr<BaseLayer> ExpCuda::to_host()
 /// AGVICuda
 ////////////////////////////////////////////////////////////////////////////////
 
-AGVICuda::AGVICuda(std::unique_ptr<BaseLayer> activation_layer, bool overfit_mu,
+AGVICuda::AGVICuda(std::unique_ptr<BaseLayer> odd_layer,
+                   std::unique_ptr<BaseLayer> even_layer, bool overfit_mu,
                    bool agvi)
-    : m_activation_layer(std::move(activation_layer)),
+    : m_odd_layer(std::move(odd_layer)),
+      m_even_layer(std::move(even_layer)),
       m_overfit_mu(overfit_mu),
       m_agvi(agvi) {}
 
-AGVICuda::~AGVICuda() {}
+AGVICuda::~AGVICuda() {
+    // The unique_ptrs for layers and HiddenStateCuda members will automatically
+    // handle the deallocation of their respective resources.
+}
 
 std::string AGVICuda::get_layer_info() const {
-    return "AGVICuda(" + m_activation_layer->get_layer_name() + ")";
+    std::string even_name =
+        m_even_layer ? m_even_layer->get_layer_name() : "Identity";
+    return "AGVICuda(odd=" + m_odd_layer->get_layer_name() +
+           ", even=" + even_name + ")";
 }
 
 std::string AGVICuda::get_layer_name() const { return "AGVICuda"; }
@@ -2212,88 +2370,135 @@ std::string AGVICuda::get_layer_name() const { return "AGVICuda"; }
 LayerType AGVICuda::get_layer_type() const { return LayerType::AGVI; }
 
 std::unique_ptr<BaseLayer> AGVICuda::to_host() {
-    auto *cuda_layer = dynamic_cast<BaseLayerCuda *>(m_activation_layer.get());
-    if (!cuda_layer) {
+    auto *odd_cuda_layer = dynamic_cast<BaseLayerCuda *>(m_odd_layer.get());
+    if (!odd_cuda_layer) {
         throw std::runtime_error(
-            "AGVICuda::to_host(): Failed to cast inner layer to "
-            "BaseLayerCuda.");
+            "AGVICuda::to_host(): Failed to cast odd_layer to BaseLayerCuda.");
     }
-    auto host_inner_layer = cuda_layer->to_host();
-    return std::make_unique<AGVI>(std::move(host_inner_layer), m_overfit_mu,
-                                  m_agvi);
+    auto host_odd_layer = odd_cuda_layer->to_host();
+
+    std::shared_ptr<BaseLayer> host_even_layer = nullptr;
+    if (m_even_layer) {
+        auto *even_cuda_layer =
+            dynamic_cast<BaseLayerCuda *>(m_even_layer.get());
+        if (!even_cuda_layer) {
+            throw std::runtime_error(
+                "AGVICuda::to_host(): Failed to cast even_layer to "
+                "BaseLayerCuda.");
+        }
+        host_even_layer = even_cuda_layer->to_host();
+    }
+
+    auto host_agvi = std::make_unique<AGVI>(std::move(host_odd_layer),
+                                            std::move(host_even_layer),
+                                            m_overfit_mu, m_agvi);
+    return host_agvi;
 }
 
 void AGVICuda::forward(BaseHiddenStates &input_states,
                        BaseHiddenStates &output_states,
                        BaseTempStates &temp_states) {
-    // Cast to CUDA-specific types
+    // 1. Cast states to CUDA-specific types
     auto *cu_input_states = dynamic_cast<HiddenStateCuda *>(&input_states);
     auto *cu_output_states = dynamic_cast<HiddenStateCuda *>(&output_states);
 
-    // Calculate sizes
+    // 2. Calculate sizes
     int total_elements =
         cu_input_states->actual_size * cu_input_states->block_size;
     int half_size = total_elements / 2;
+    size_t half_bytes = half_size * sizeof(float);
 
-    // Set output dimensions
+    // 3. Set output dimensions (output is half the size of the input)
     cu_output_states->actual_size = cu_input_states->actual_size / 2;
     cu_output_states->block_size = cu_input_states->block_size;
     this->input_size = cu_input_states->actual_size;
     this->output_size = cu_output_states->actual_size;
 
-    // 1. Prepare states for the inner activation layer (odd stream)
+    // 4. Prepare temporary states for the odd stream processing
     HiddenStateCuda odd_input_states;
     odd_input_states.block_size = cu_input_states->block_size;
     odd_input_states.actual_size = cu_input_states->actual_size / 2;
+    cudaMalloc(&odd_input_states.d_mu_a, half_bytes);
+    cudaMalloc(&odd_input_states.d_var_a, half_bytes);
+    cudaMalloc(&odd_input_states.d_jcb, half_bytes);
 
-    // Allocate memory for odd input states
-    {
-        size_t size = odd_input_states.block_size *
-                      odd_input_states.actual_size * sizeof(float);
-        cudaMalloc(&odd_input_states.d_mu_a, size);
-        cudaMalloc(&odd_input_states.d_var_a, size);
-        cudaMalloc(&odd_input_states.d_jcb, size);
-    }
-
-    // 2. Launch kernel to extract the odd-indexed elements from the input
+    // 5. Setup CUDA launch configuration
     unsigned int threads = 256;
     unsigned int blocks = (half_size + threads - 1) / threads;
+
+    // 6. Extract odd stream from input
     agvi_extract_odd_stream_kernel<<<blocks, threads>>>(
         cu_input_states->d_mu_a, cu_input_states->d_var_a,
         cu_input_states->d_jcb, half_size, odd_input_states.d_mu_a,
         odd_input_states.d_var_a, odd_input_states.d_jcb);
 
-    // 3. Allocate memory for the inner activation output and call its forward
-    // pass
-    m_stored_inner_output_states.block_size = odd_input_states.block_size;
-    m_stored_inner_output_states.actual_size = odd_input_states.actual_size;
+    // 7. Process the odd stream through its activation layer
+    m_stored_inner_output_states.actual_size =
+        half_size / cu_input_states->block_size;
+    m_stored_inner_output_states.block_size = cu_input_states->block_size;
+    cudaMalloc(&m_stored_inner_output_states.d_mu_a, half_bytes);
+    cudaMalloc(&m_stored_inner_output_states.d_var_a, half_bytes);
+    cudaMalloc(&m_stored_inner_output_states.d_jcb, half_bytes);
+    m_odd_layer->forward(odd_input_states, m_stored_inner_output_states,
+                         temp_states);
 
-    // Allocate memory for the inner activation output states
-    {
-        size_t size = m_stored_inner_output_states.block_size *
-                      m_stored_inner_output_states.actual_size * sizeof(float);
-        cudaMalloc(&m_stored_inner_output_states.d_mu_a, size);
-        cudaMalloc(&m_stored_inner_output_states.d_var_a, size);
-        cudaMalloc(&m_stored_inner_output_states.d_jcb, size);
+    // 8. Process the even stream
+    m_stored_even_output_states.actual_size =
+        half_size / cu_input_states->block_size;
+    m_stored_even_output_states.block_size = cu_input_states->block_size;
+    cudaMalloc(&m_stored_even_output_states.d_mu_a, half_bytes);
+    cudaMalloc(&m_stored_even_output_states.d_var_a, half_bytes);
+    cudaMalloc(&m_stored_even_output_states.d_jcb, half_bytes);
+
+    if (m_even_layer) {
+        // If an even layer is provided, extract even inputs and process them
+        HiddenStateCuda even_input_states;
+        even_input_states.actual_size = half_size / cu_input_states->block_size;
+        even_input_states.block_size = cu_input_states->block_size;
+        cudaMalloc(&even_input_states.d_mu_a, half_bytes);
+        cudaMalloc(&even_input_states.d_var_a, half_bytes);
+        cudaMalloc(&even_input_states.d_jcb, half_bytes);
+
+        // Use the general-purpose split kernel to get even inputs
+        split_stream_kernel<<<blocks, threads>>>(
+            cu_input_states->d_mu_a, cu_input_states->d_var_a,
+            cu_input_states->d_jcb, half_size, even_input_states.d_mu_a,
+            even_input_states.d_var_a, even_input_states.d_jcb,
+            odd_input_states.d_mu_a, odd_input_states.d_var_a,
+            odd_input_states.d_jcb);
+
+        m_even_layer->forward(even_input_states, m_stored_even_output_states,
+                              temp_states);
+
+        cudaFree(even_input_states.d_mu_a);
+        cudaFree(even_input_states.d_var_a);
+        cudaFree(even_input_states.d_jcb);
+        even_input_states.d_mu_a = nullptr;
+        even_input_states.d_var_a = nullptr;
+        even_input_states.d_jcb = nullptr;
+    } else {
+        // Identity: just extract the even stream directly into the stored state
+        split_stream_kernel<<<blocks, threads>>>(
+            cu_input_states->d_mu_a, cu_input_states->d_var_a,
+            cu_input_states->d_jcb, half_size,
+            m_stored_even_output_states.d_mu_a,
+            m_stored_even_output_states.d_var_a,
+            m_stored_even_output_states.d_jcb, odd_input_states.d_mu_a,
+            odd_input_states.d_var_a, odd_input_states.d_jcb);
     }
 
-    // Forward the inner activation layer
-    m_activation_layer->forward(odd_input_states, m_stored_inner_output_states,
-                                temp_states);
-
-    // 4. Launch kernel to combine the even stream and inner activation output
+    // 9. Combine results into the final output using the CORRECTED kernel
     agvi_forward_combine_kernel<<<blocks, threads>>>(
-        cu_input_states->d_mu_a, cu_input_states->d_var_a,
-        cu_input_states->d_jcb, m_stored_inner_output_states.d_mu_a, half_size,
+        m_stored_even_output_states.d_mu_a, m_stored_even_output_states.d_var_a,
+        m_stored_inner_output_states.d_mu_a, half_size,
         cu_output_states->d_mu_a, cu_output_states->d_var_a,
         cu_output_states->d_jcb, m_agvi);
 
-    // 5. Store pointers for the backward pass
-    d_stored_input_var_a = cu_input_states->d_var_a;
+    // 10. Store pointers to final output states for the backward pass
     d_stored_output_mu_a = cu_output_states->d_mu_a;
     d_stored_output_var_a = cu_output_states->d_var_a;
 
-    // Deallocate the odd input states memory
+    // 11. Clean up temporary odd input memory
     cudaFree(odd_input_states.d_mu_a);
     cudaFree(odd_input_states.d_var_a);
     cudaFree(odd_input_states.d_jcb);
@@ -2305,35 +2510,49 @@ void AGVICuda::forward(BaseHiddenStates &input_states,
 void AGVICuda::backward(BaseDeltaStates &input_delta_states,
                         BaseDeltaStates &output_delta_states,
                         BaseTempStates &temp_states, bool state_update) {
+    // 1. Cast states to CUDA-specific types
     auto *cu_input_delta = dynamic_cast<DeltaStateCuda *>(&input_delta_states);
     auto *cu_output_delta =
         dynamic_cast<DeltaStateCuda *>(&output_delta_states);
 
+    // 2. Calculate size for kernel launch
     int half_size = this->output_size * cu_input_delta->block_size;
 
+    // 3. Set up CUDA launch configuration
     unsigned int threads = 256;
     unsigned int blocks = (half_size + threads - 1) / threads;
+
+    // 4. Launch the backward kernel
     agvi_backward_kernel<<<blocks, threads>>>(
         cu_input_delta->d_delta_mu, cu_input_delta->d_delta_var,
         d_stored_output_mu_a, d_stored_output_var_a,
         m_stored_inner_output_states.d_mu_a,
         m_stored_inner_output_states.d_var_a,
-        m_stored_inner_output_states.d_jcb, d_stored_input_var_a, half_size,
-        cu_output_delta->d_delta_mu, cu_output_delta->d_delta_var,
-        m_overfit_mu);  // Pass the flag here
+        m_stored_inner_output_states.d_jcb, m_stored_even_output_states.d_var_a,
+        m_stored_even_output_states.d_jcb, half_size,
+        cu_output_delta->d_delta_mu, cu_output_delta->d_delta_var, m_overfit_mu,
+        m_even_layer != nullptr);
 
+    // 5. Update output delta metadata
     cu_output_delta->actual_size = this->input_size;
     cu_output_delta->block_size = cu_input_delta->block_size;
 
-    // Free memory used for storing inner states.
-    // The other d_stored_* pointers are just views and don't own memory.
+    // 6. Free memory that was stored for the backward pass
     cudaFree(m_stored_inner_output_states.d_mu_a);
     cudaFree(m_stored_inner_output_states.d_var_a);
     cudaFree(m_stored_inner_output_states.d_jcb);
     m_stored_inner_output_states.d_mu_a = nullptr;
     m_stored_inner_output_states.d_var_a = nullptr;
     m_stored_inner_output_states.d_jcb = nullptr;
-    d_stored_input_var_a = nullptr;
+
+    cudaFree(m_stored_even_output_states.d_mu_a);
+    cudaFree(m_stored_even_output_states.d_var_a);
+    cudaFree(m_stored_even_output_states.d_jcb);
+    m_stored_even_output_states.d_mu_a = nullptr;
+    m_stored_even_output_states.d_var_a = nullptr;
+    m_stored_even_output_states.d_jcb = nullptr;
+
+    // Reset non-owning pointers to prevent dangling references
     d_stored_output_mu_a = nullptr;
     d_stored_output_var_a = nullptr;
 }

--- a/src/activation_cuda.cu
+++ b/src/activation_cuda.cu
@@ -117,6 +117,22 @@ __global__ void tanh_mean_var_cuda(float const *mu_z, float const *var_z,
         jcb[col] = (1.0f - tmp_2);
         var_a[col] = (1.0f - tmp_2) * var_z[col] * (1.0f - tmp_2);
     }
+
+    // printf("mean_var_cuda: mu_z[%d]=%f, var_z[%d]=%f\n", col, mu_z[col],
+    //            col, var_z[col]);
+
+    //     float delta = 20.0f;
+    //     float sign = (mu_z[col] >= 0.0f) ? 1.0f : -1.0f;
+
+    //     if (std::abs(mu_z[col]) > delta) {
+    //         mu_a[col] = sign * delta;
+    //         jcb[col] = 0.0f;
+    //         var_a[col] = 0.0f;
+    //     } else {
+    //         mu_a[col] = mu_z[col];
+    //         var_a[col] = var_z[col];
+    //         jcb[col] = 1.0f;
+    //     }
 }
 
 __device__ float normcdf_cuda(float x)
@@ -314,28 +330,6 @@ __global__ void softmax_mean_var_cuda(float const *mu_z, float *var_z,
     }
 }
 
-__global__ void even_exp_mean_var_cuda(float const *mu_z, float const *var_z,
-                                       float const *jcb_z, int num_states,
-                                       float *mu_a, float *var_a, float *jcb_a)
-/*
- */
-{
-    int col = blockIdx.x * blockDim.x + threadIdx.x;
-
-    if (col < num_states) {
-        if (col % 2 == 0) {
-            mu_a[col] = mu_z[col];
-            var_a[col] = var_z[col];
-            jcb_a[col] = jcb_z[col];
-        } else {
-            mu_a[col] = expf(mu_z[col] + 0.5f * var_z[col]);
-            var_a[col] =
-                expf(2.0f * mu_z[col] + var_z[col]) * (expf(var_z[col]) - 1.0f);
-            jcb_a[col] = var_z[col] * mu_a[col];
-        }
-    }
-}
-
 ////////////////////////////////////////////////////////////////////////////////
 /// Remax kernels
 ////////////////////////////////////////////////////////////////////////////////
@@ -477,6 +471,190 @@ __global__ void compute_cov_a_z_cuda_v2(float const *mu_a, float const *var_a,
                 cdfn[row * hidden_size + col] / var_m[row * hidden_size + col]);
 
         cov_a_z[row * hidden_size + col] /= var_z[row * hidden_size + col];
+    }
+}
+
+__global__ void split_stream_kernel(const float *d_in_mu, const float *d_in_var,
+                                    const float *d_in_jcb, int half_size,
+                                    float *d_even_mu, float *d_even_var,
+                                    float *d_even_jcb, float *d_odd_mu,
+                                    float *d_odd_var, float *d_odd_jcb) {
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i < half_size) {
+        // Handle even index
+        int even_idx = 2 * i;
+        d_even_mu[i] = d_in_mu[even_idx];
+        d_even_var[i] = d_in_var[even_idx];
+        d_even_jcb[i] = d_in_jcb[even_idx];
+
+        // Handle odd index
+        int odd_idx = 2 * i + 1;
+        d_odd_mu[i] = d_in_mu[odd_idx];
+        d_odd_var[i] = d_in_var[odd_idx];
+        d_odd_jcb[i] = d_in_jcb[odd_idx];
+    }
+}
+
+__global__ void merge_stream_kernel(
+    const float *d_even_mu, const float *d_even_var, const float *d_even_jcb,
+    const float *d_odd_mu, const float *d_odd_var, const float *d_odd_jcb,
+    int half_size, float *d_out_mu, float *d_out_var, float *d_out_jcb) {
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i < half_size) {
+        // Handle even index
+        int even_idx = 2 * i;
+        d_out_mu[even_idx] = d_even_mu[i];
+        d_out_var[even_idx] = d_even_var[i];
+        d_out_jcb[even_idx] = d_even_jcb[i];
+
+        // Handle odd index
+        int odd_idx = 2 * i + 1;
+        d_out_mu[odd_idx] = d_odd_mu[i];
+        d_out_var[odd_idx] = d_odd_var[i];
+        d_out_jcb[odd_idx] = d_odd_jcb[i];
+    }
+}
+
+__global__ void exp_mean_var_cuda(float const *mu_z, float const *var_z,
+                                  float const *jcb_z, int num_states,
+                                  float *mu_a, float *var_a, float *jcb_a,
+                                  float scale, float shift)
+/*
+ */
+{
+    int col = blockIdx.x * blockDim.x + threadIdx.x;
+
+    if (col < num_states) {
+        float new_var_z = var_z[col] * (scale * scale);
+        // Calculate the new mean of the input z, and constrain it
+        float new_mu_z = mu_z[col] * scale + shift;
+
+        // Calculate the output mean using the constrained new_mu_z
+        mu_a[col] = expf(new_mu_z + 0.5f * new_var_z);
+
+        // Calculate the output variance using the constrained new_mu_z
+        var_a[col] =
+            expf(2.0f * new_mu_z + new_var_z) * (expf(new_var_z) - 1.0f);
+
+        // Calculate the Jacobian based on the constrained new_mu_z
+        jcb_a[col] = mu_a[col] * scale;
+    }
+}
+
+__global__ void agvi_extract_odd_stream_kernel(
+    const float *d_input_mu, const float *d_input_var, const float *d_input_jcb,
+    int half_size, float *d_odd_mu, float *d_odd_var, float *d_odd_jcb) {
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i < half_size) {
+        int input_idx = 2 * i + 1;
+        d_odd_mu[i] = d_input_mu[input_idx];
+        d_odd_var[i] = d_input_var[input_idx];
+        d_odd_jcb[i] = d_input_jcb[input_idx];
+    }
+}
+
+__global__ void agvi_forward_combine_kernel(
+    const float *d_input_mu, const float *d_input_var, const float *d_input_jcb,
+    const float *d_inner_output_mu, int half_size, float *d_output_mu,
+    float *d_output_var, float *d_output_jcb, bool agvi) {
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i < half_size) {
+        int even_input_idx = 2 * i;
+        d_output_mu[i] = d_input_mu[even_input_idx];
+        d_output_jcb[i] = d_input_jcb[even_input_idx];
+        if (agvi)
+            d_output_var[i] =
+                d_input_var[even_input_idx] + d_inner_output_mu[i];
+        else
+            d_output_var[i] = d_input_var[even_input_idx];
+    }
+}
+
+__global__ void agvi_backward_kernel(
+    const float *d_incoming_delta_mu, const float *d_incoming_delta_var,
+    const float *d_stored_output_mu_a, const float *d_stored_output_var_a,
+    const float *d_stored_inner_mu_a, const float *d_stored_inner_var_a,
+    const float *d_stored_inner_jcb, const float *d_stored_input_var_a,
+    int half_size, float *d_output_delta_mu, float *d_output_delta_var,
+    bool overfit_mu) {
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+
+    const float epsilon = 1e-12f;
+
+    if (i < half_size) {
+        float mu_a = d_stored_output_mu_a[i];
+        float var_a = fmaxf(d_stored_output_var_a[i], epsilon);
+
+        float mu_v2_bar_tilde = d_stored_inner_mu_a[i];
+        float var_v2_bar_tilde = d_stored_inner_var_a[i];
+        float jcb_v2_bar_tilde = d_stored_inner_jcb[i];
+
+        float incoming_delta_mu = d_incoming_delta_mu[i];
+        float incoming_delta_var = d_incoming_delta_var[i];
+
+        float var_z = d_stored_input_var_a[i * 2];
+
+        float delta_a_mu = incoming_delta_mu * var_a;
+        float delta_a_var = incoming_delta_var * var_a * var_a;
+
+        float mu_v2 = mu_v2_bar_tilde;
+        float var_v2 =
+            3.0f * var_v2_bar_tilde + 2.0f * mu_v2_bar_tilde * mu_v2_bar_tilde;
+
+        float Jv = mu_v2_bar_tilde / fmaxf(var_a, epsilon);
+
+        float mu_v_pos = Jv * delta_a_mu;
+        float var_v_pos = mu_v2_bar_tilde + Jv * Jv * delta_a_var;
+
+        float mu_v2_pos = mu_v_pos * mu_v_pos + var_v_pos;
+        float var_v2_pos = 2.0f * var_v_pos * var_v_pos +
+                           4.0f * var_v_pos * mu_v_pos * mu_v_pos;
+
+        float Jv2_bar_tilde = var_v2_bar_tilde / fmaxf(var_v2, epsilon);
+        float mu_v2_bar_tilde_pos =
+            mu_v2_bar_tilde + Jv2_bar_tilde * (mu_v2_pos - mu_v2);
+        float var_v2_bar_tilde_pos =
+            var_v2_bar_tilde +
+            Jv2_bar_tilde * Jv2_bar_tilde * (var_v2_pos - var_v2);
+
+        int even_idx = 2 * i;
+        int odd_idx = 2 * i + 1;
+
+        float Jv2_bar = jcb_v2_bar_tilde / fmaxf(var_v2_bar_tilde, epsilon);
+
+        float odd_delta_mu = Jv2_bar * (mu_v2_bar_tilde_pos - mu_v2_bar_tilde);
+        float odd_delta_var =
+            Jv2_bar * Jv2_bar * (var_v2_bar_tilde_pos - var_v2_bar_tilde);
+
+        if (isnan(odd_delta_mu) || isinf(odd_delta_mu) ||
+            isnan(odd_delta_var) || isinf(odd_delta_var)) {
+            odd_delta_mu = 0.0f;
+            odd_delta_var = 0.0f;
+        }
+
+        d_output_delta_mu[odd_idx] = odd_delta_mu;
+        d_output_delta_var[odd_idx] = odd_delta_var;
+
+        float Jz = 1.0f / (var_a);
+        float Jz_mu;
+        if (overfit_mu) {
+            Jz_mu = 1.0f / (var_z);
+        } else {
+            Jz_mu = Jz;
+        }
+
+        float even_delta_mu = Jz_mu * delta_a_mu;
+        float even_delta_var = Jz * Jz * delta_a_var;
+
+        // Check and handle potential NaN or Inf values for even stream deltas.
+        if (isnan(even_delta_mu) || isinf(even_delta_mu) ||
+            isnan(even_delta_var) || isinf(even_delta_var)) {
+            even_delta_mu = 0.0f;
+            even_delta_var = 0.0f;
+        }
+
+        d_output_delta_mu[even_idx] = even_delta_mu;
+        d_output_delta_var[even_idx] = even_delta_var;
     }
 }
 
@@ -910,6 +1088,69 @@ std::unique_ptr<BaseLayer> MixtureTanhCuda::to_host()
 
     return host_layer;
 }
+
+////////////////////////////////////////////////////////////////////////////////
+// CELU + alpha
+////////////////////////////////////////////////////////////////////////////////
+
+// // Configuration constants
+//     constexpr float EPS = 1e-9;        // floor for variance
+//     constexpr float MIN_TAIL = 1e-20;  // clamp for tail
+//     constexpr float SQRT_2PI = 2.5066282746310002;
+//     constexpr float INV_SQRT2 = 0.7071067811865475;
+//     constexpr float ALPHA = 0.2;  // slope of negative part
+
+//     // inside your kernel, per-element:
+//     float mz = mu_z[col];
+//     float varz = var_z[col];
+
+//     mz = mz / 1.0f - 0.0f;        // Scale and shift the mean
+//     varz = varz / (1.0f * 1.0f);  // Scale the variance
+
+//     // 1) std-dev and standardize
+//     float sz = sqrt(varz);
+//     float z = mz / sz;
+
+//     // 2) shift amount
+//     float a = sz / ALPHA;
+//     float z_a = z + a;
+//     float z_2a = z + 2.0 * a;
+
+//     // 3) φ(z) and tail probs P[Z < −x] = 0.5*erfc(x/√2), clamped
+//     float phi_z = exp(-0.5 * z * z) / SQRT_2PI;
+
+//     float tail_z = 0.5 * erfc(z * INV_SQRT2);
+//     float tail_za = 0.5 * erfc(z_a * INV_SQRT2);
+//     float tail_z2a = 0.5 * erfc(z_2a * INV_SQRT2);
+
+//     // 4) analytic ratios instead of φ(z)/φ(z+k·a)
+//     float exp_a = exp(a * z + 0.5 * (a * a));
+//     float exp_2a = exp(2 * a * z + 0.5 * (2 * a) * (2 * a));
+
+//     // 5) Mean E[CELU(z)]
+//     float mean_d =
+//         mz + sz * phi_z - (ALPHA + mz) * tail_z + ALPHA * tail_za * exp_a;
+
+//     // 6) Second moment E[CELU(z)²]
+//     float E2 = mz * mz + mz * sz * phi_z + varz -
+//                2.0 * ALPHA * ALPHA * tail_za * exp_a +
+//                ALPHA * ALPHA * tail_z2a * exp_2a +
+//                (ALPHA * ALPHA - mz * mz - varz) * tail_z;
+
+//     // 7) Variance = E2 – mean², with floor
+//     float var_d = E2 - mean_d * mean_d;
+
+//     // 8) Covariance Cov[z, CELU(z)] = varz * (P[Z> -z] + tail_za·exp_a)
+//     float cov_d = varz * ((1.0 - tail_z) + tail_za * exp_a);
+
+//     // 9) Jacobian in [0,1]
+//     float jcb_d = cov_d / varz;
+//     // jcb_d = fmin(fmax(jcb_d, 0.0), 1.0);
+
+//     // 10) Store back (cast to float, clamp mean+α > 0)
+//     mu_a[col] = fmax(mean_d + ALPHA, 0.000001f);
+//     var_a[col] = fmaxf(var_d, 0.000001f);
+//     jcb[col] = jcb_d / 1.0f;  // Scale back the jacobian
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Softplus
@@ -1637,35 +1878,184 @@ void ClosedFormSoftmaxCuda::data_to_device() {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// EvenExp
+/// SplitActivationCuda
 ////////////////////////////////////////////////////////////////////////////////
-EvenExpCuda::EvenExpCuda() {}
-EvenExpCuda::~EvenExpCuda() {}
 
-std::string EvenExpCuda::get_layer_info() const
+SplitActivationCuda::SplitActivationCuda(std::unique_ptr<BaseLayer> odd_layer,
+                                         std::unique_ptr<BaseLayer> even_layer)
+    : odd_layer(std::move(odd_layer)), even_layer(std::move(even_layer)) {}
+
+SplitActivationCuda::~SplitActivationCuda() {}
+
+std::string SplitActivationCuda::get_layer_info() const {
+    std::string even_layer_name = "Identity";
+    if (even_layer) {
+        even_layer_name = even_layer->get_layer_name();
+    }
+    return "SplitActivationCuda(odd=" + odd_layer->get_layer_name() +
+           ", even=" + even_layer_name + ")";
+}
+
+std::string SplitActivationCuda::get_layer_name() const {
+    return "SplitActivationCuda";
+}
+
+LayerType SplitActivationCuda::get_layer_type() const {
+    return LayerType::Activation;
+}
+
+std::unique_ptr<BaseLayer> SplitActivationCuda::to_host() {
+    auto *odd_cuda_layer = dynamic_cast<BaseLayerCuda *>(odd_layer.get());
+    auto host_odd_layer = odd_cuda_layer->to_host();
+
+    std::shared_ptr<BaseLayer> host_even_layer = nullptr;
+    if (even_layer) {
+        auto *even_cuda_layer = dynamic_cast<BaseLayerCuda *>(even_layer.get());
+        host_even_layer = even_cuda_layer->to_host();
+    }
+
+    return std::make_unique<SplitActivation>(std::move(host_odd_layer),
+                                             std::move(host_even_layer));
+}
+
+void SplitActivationCuda::forward(BaseHiddenStates &input_states,
+                                  BaseHiddenStates &output_states,
+                                  BaseTempStates &temp_states) {
+    // 1. Cast states to CUDA-specific types
+    HiddenStateCuda *cu_input_states =
+        dynamic_cast<HiddenStateCuda *>(&input_states);
+    HiddenStateCuda *cu_output_states =
+        dynamic_cast<HiddenStateCuda *>(&output_states);
+
+    // 2. Calculate sizes
+    int total_elements =
+        cu_input_states->actual_size * cu_input_states->block_size;
+    int half_size = total_elements / 2;
+
+    // 3. Prepare temporary states for split streams
+    HiddenStateCuda odd_input_states, even_input_states;
+    cudaMalloc(&odd_input_states.d_mu_a, half_size * sizeof(float));
+    cudaMalloc(&odd_input_states.d_var_a, half_size * sizeof(float));
+    cudaMalloc(&odd_input_states.d_jcb, half_size * sizeof(float));
+    cudaMalloc(&even_input_states.d_mu_a, half_size * sizeof(float));
+    cudaMalloc(&even_input_states.d_var_a, half_size * sizeof(float));
+    cudaMalloc(&even_input_states.d_jcb, half_size * sizeof(float));
+
+    odd_input_states.block_size = cu_input_states->block_size;
+    odd_input_states.actual_size = half_size / cu_input_states->block_size;
+    even_input_states.block_size = cu_input_states->block_size;
+    even_input_states.actual_size = half_size / cu_input_states->block_size;
+
+    // 4. Launch kernel to split the input stream
+    unsigned int threads = 256;
+    unsigned int blocks = (half_size + threads - 1) / threads;
+    split_stream_kernel<<<blocks, threads>>>(
+        cu_input_states->d_mu_a, cu_input_states->d_var_a,
+        cu_input_states->d_jcb, half_size, even_input_states.d_mu_a,
+        even_input_states.d_var_a, even_input_states.d_jcb,
+        odd_input_states.d_mu_a, odd_input_states.d_var_a,
+        odd_input_states.d_jcb);
+
+    // 5. Process the streams
+    HiddenStateCuda odd_output_states, even_output_states;
+    // odd_output_states.allocate(half_size);
+    // even_output_states.allocate(half_size);
+    cudaMalloc(&odd_output_states.d_mu_a, half_size * sizeof(float));
+    cudaMalloc(&odd_output_states.d_var_a, half_size * sizeof(float));
+    cudaMalloc(&odd_output_states.d_jcb, half_size * sizeof(float));
+    cudaMalloc(&even_output_states.d_mu_a, half_size * sizeof(float));
+    cudaMalloc(&even_output_states.d_var_a, half_size * sizeof(float));
+    cudaMalloc(&even_output_states.d_jcb, half_size * sizeof(float));
+
+    // Process odd stream (mandatory)
+    odd_layer->forward(odd_input_states, odd_output_states, temp_states);
+
+    // Process even stream (optional)
+    if (even_layer) {
+        even_layer->forward(even_input_states, even_output_states, temp_states);
+    } else {
+        // Identity: Copy even input directly to even output
+        cudaMemcpy(even_output_states.d_mu_a, even_input_states.d_mu_a,
+                   half_size * sizeof(float), cudaMemcpyDeviceToDevice);
+        cudaMemcpy(even_output_states.d_var_a, even_input_states.d_var_a,
+                   half_size * sizeof(float), cudaMemcpyDeviceToDevice);
+        cudaMemcpy(even_output_states.d_jcb, even_input_states.d_jcb,
+                   half_size * sizeof(float), cudaMemcpyDeviceToDevice);
+    }
+
+    // 6. Launch kernel to merge the processed streams
+    merge_stream_kernel<<<blocks, threads>>>(
+        even_output_states.d_mu_a, even_output_states.d_var_a,
+        even_output_states.d_jcb, odd_output_states.d_mu_a,
+        odd_output_states.d_var_a, odd_output_states.d_jcb, half_size,
+        cu_output_states->d_mu_a, cu_output_states->d_var_a,
+        cu_output_states->d_jcb);
+
+    // 7. Update output state metadata
+    cu_output_states->actual_size = cu_input_states->actual_size;
+    cu_output_states->block_size = cu_input_states->block_size;
+    if (this->input_size != input_states.actual_size) {
+        this->input_size = input_states.actual_size;
+        this->output_size = input_states.actual_size;
+    }
+
+    // 8. Free temporary device memory
+    cudaFree(odd_input_states.d_mu_a);
+    cudaFree(odd_input_states.d_var_a);
+    cudaFree(odd_input_states.d_jcb);
+    cudaFree(even_input_states.d_mu_a);
+    cudaFree(even_input_states.d_var_a);
+    cudaFree(even_input_states.d_jcb);
+    cudaFree(odd_output_states.d_mu_a);
+    cudaFree(odd_output_states.d_var_a);
+    cudaFree(odd_output_states.d_jcb);
+    cudaFree(even_output_states.d_mu_a);
+    cudaFree(even_output_states.d_var_a);
+    cudaFree(even_output_states.d_jcb);
+    odd_input_states.d_mu_a = nullptr;
+    odd_input_states.d_var_a = nullptr;
+    odd_input_states.d_jcb = nullptr;
+    even_input_states.d_mu_a = nullptr;
+    even_input_states.d_var_a = nullptr;
+    even_input_states.d_jcb = nullptr;
+    odd_output_states.d_mu_a = nullptr;
+    odd_output_states.d_var_a = nullptr;
+    odd_output_states.d_jcb = nullptr;
+    even_output_states.d_mu_a = nullptr;
+    even_output_states.d_var_a = nullptr;
+    even_output_states.d_jcb = nullptr;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Exp
+////////////////////////////////////////////////////////////////////////////////
+ExpCuda::ExpCuda(float scale, float shift) : scale(scale), shift(shift) {}
+ExpCuda::~ExpCuda() {}
+
+std::string ExpCuda::get_layer_info() const
 /*
  */
 {
-    return "EvenExp()";
+    return "Exp()";
 }
 
-std::string EvenExpCuda::get_layer_name() const
+std::string ExpCuda::get_layer_name() const
 /*
  */
 {
-    return "EvenExpCuda";
+    return "ExpCuda";
 }
 
-LayerType EvenExpCuda::get_layer_type() const
+LayerType ExpCuda::get_layer_type() const
 /*
  */
 {
     return LayerType::Activation;
 }
 
-void EvenExpCuda::forward(BaseHiddenStates &input_states,
-                          BaseHiddenStates &output_states,
-                          BaseTempStates &temp_states)
+void ExpCuda::forward(BaseHiddenStates &input_states,
+                      BaseHiddenStates &output_states,
+                      BaseTempStates &temp_states)
 /*
  */
 {
@@ -1686,10 +2076,10 @@ void EvenExpCuda::forward(BaseHiddenStates &input_states,
     cu_output_states->block_size = cu_input_states->block_size;
     cu_output_states->actual_size = cu_input_states->actual_size;
 
-    even_exp_mean_var_cuda<<<blocks, this->num_cuda_threads>>>(
+    exp_mean_var_cuda<<<blocks, this->num_cuda_threads>>>(
         cu_input_states->d_mu_a, cu_input_states->d_var_a,
         cu_input_states->d_jcb, num_states, cu_output_states->d_mu_a,
-        cu_output_states->d_var_a, cu_output_states->d_jcb);
+        cu_output_states->d_var_a, cu_output_states->d_jcb, scale, shift);
 
     if (this->input_size != input_states.actual_size) {
         this->input_size = input_states.actual_size;
@@ -1701,13 +2091,160 @@ void EvenExpCuda::forward(BaseHiddenStates &input_states,
     cu_output_states->actual_size = cu_input_states->actual_size;
 }
 
-std::unique_ptr<BaseLayer> EvenExpCuda::to_host()
+std::unique_ptr<BaseLayer> ExpCuda::to_host()
 /* Transfer to cpu version
  */
 {
-    std::unique_ptr<BaseLayer> host_layer = std::make_unique<EvenExp>();
+    std::unique_ptr<BaseLayer> host_layer = std::make_unique<Exp>(scale, shift);
     host_layer->input_size = this->input_size;
     host_layer->output_size = this->output_size;
 
     return host_layer;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// AGVICuda
+////////////////////////////////////////////////////////////////////////////////
+
+AGVICuda::AGVICuda(std::unique_ptr<BaseLayer> activation_layer, bool overfit_mu,
+                   bool agvi)
+    : m_activation_layer(std::move(activation_layer)),
+      m_overfit_mu(overfit_mu),
+      m_agvi(agvi) {}
+
+AGVICuda::~AGVICuda() {}
+
+std::string AGVICuda::get_layer_info() const {
+    return "AGVICuda(" + m_activation_layer->get_layer_name() + ")";
+}
+
+std::string AGVICuda::get_layer_name() const { return "AGVICuda"; }
+
+LayerType AGVICuda::get_layer_type() const { return LayerType::AGVI; }
+
+std::unique_ptr<BaseLayer> AGVICuda::to_host() {
+    auto *cuda_layer = dynamic_cast<BaseLayerCuda *>(m_activation_layer.get());
+    if (!cuda_layer) {
+        throw std::runtime_error(
+            "AGVICuda::to_host(): Failed to cast inner layer to "
+            "BaseLayerCuda.");
+    }
+    auto host_inner_layer = cuda_layer->to_host();
+    return std::make_unique<AGVI>(std::move(host_inner_layer), m_overfit_mu,
+                                  m_agvi);
+}
+
+void AGVICuda::forward(BaseHiddenStates &input_states,
+                       BaseHiddenStates &output_states,
+                       BaseTempStates &temp_states) {
+    // Cast to CUDA-specific types
+    auto *cu_input_states = dynamic_cast<HiddenStateCuda *>(&input_states);
+    auto *cu_output_states = dynamic_cast<HiddenStateCuda *>(&output_states);
+
+    // Calculate sizes
+    int total_elements =
+        cu_input_states->actual_size * cu_input_states->block_size;
+    int half_size = total_elements / 2;
+
+    // Set output dimensions
+    cu_output_states->actual_size = cu_input_states->actual_size / 2;
+    cu_output_states->block_size = cu_input_states->block_size;
+    this->input_size = cu_input_states->actual_size;
+    this->output_size = cu_output_states->actual_size;
+
+    // 1. Prepare states for the inner activation layer (odd stream)
+    HiddenStateCuda odd_input_states;
+    odd_input_states.block_size = cu_input_states->block_size;
+    odd_input_states.actual_size = cu_input_states->actual_size / 2;
+
+    // Allocate memory for odd input states
+    {
+        size_t size = odd_input_states.block_size *
+                      odd_input_states.actual_size * sizeof(float);
+        cudaMalloc(&odd_input_states.d_mu_a, size);
+        cudaMalloc(&odd_input_states.d_var_a, size);
+        cudaMalloc(&odd_input_states.d_jcb, size);
+    }
+
+    // 2. Launch kernel to extract the odd-indexed elements from the input
+    unsigned int threads = 256;
+    unsigned int blocks = (half_size + threads - 1) / threads;
+    agvi_extract_odd_stream_kernel<<<blocks, threads>>>(
+        cu_input_states->d_mu_a, cu_input_states->d_var_a,
+        cu_input_states->d_jcb, half_size, odd_input_states.d_mu_a,
+        odd_input_states.d_var_a, odd_input_states.d_jcb);
+
+    // 3. Allocate memory for the inner activation output and call its forward
+    // pass
+    m_stored_inner_output_states.block_size = odd_input_states.block_size;
+    m_stored_inner_output_states.actual_size = odd_input_states.actual_size;
+
+    // Allocate memory for the inner activation output states
+    {
+        size_t size = m_stored_inner_output_states.block_size *
+                      m_stored_inner_output_states.actual_size * sizeof(float);
+        cudaMalloc(&m_stored_inner_output_states.d_mu_a, size);
+        cudaMalloc(&m_stored_inner_output_states.d_var_a, size);
+        cudaMalloc(&m_stored_inner_output_states.d_jcb, size);
+    }
+
+    // Forward the inner activation layer
+    m_activation_layer->forward(odd_input_states, m_stored_inner_output_states,
+                                temp_states);
+
+    // 4. Launch kernel to combine the even stream and inner activation output
+    agvi_forward_combine_kernel<<<blocks, threads>>>(
+        cu_input_states->d_mu_a, cu_input_states->d_var_a,
+        cu_input_states->d_jcb, m_stored_inner_output_states.d_mu_a, half_size,
+        cu_output_states->d_mu_a, cu_output_states->d_var_a,
+        cu_output_states->d_jcb, m_agvi);
+
+    // 5. Store pointers for the backward pass
+    d_stored_input_var_a = cu_input_states->d_var_a;
+    d_stored_output_mu_a = cu_output_states->d_mu_a;
+    d_stored_output_var_a = cu_output_states->d_var_a;
+
+    // Deallocate the odd input states memory
+    cudaFree(odd_input_states.d_mu_a);
+    cudaFree(odd_input_states.d_var_a);
+    cudaFree(odd_input_states.d_jcb);
+    odd_input_states.d_mu_a = nullptr;
+    odd_input_states.d_var_a = nullptr;
+    odd_input_states.d_jcb = nullptr;
+}
+
+void AGVICuda::backward(BaseDeltaStates &input_delta_states,
+                        BaseDeltaStates &output_delta_states,
+                        BaseTempStates &temp_states, bool state_update) {
+    auto *cu_input_delta = dynamic_cast<DeltaStateCuda *>(&input_delta_states);
+    auto *cu_output_delta =
+        dynamic_cast<DeltaStateCuda *>(&output_delta_states);
+
+    int half_size = this->output_size * cu_input_delta->block_size;
+
+    unsigned int threads = 256;
+    unsigned int blocks = (half_size + threads - 1) / threads;
+    agvi_backward_kernel<<<blocks, threads>>>(
+        cu_input_delta->d_delta_mu, cu_input_delta->d_delta_var,
+        d_stored_output_mu_a, d_stored_output_var_a,
+        m_stored_inner_output_states.d_mu_a,
+        m_stored_inner_output_states.d_var_a,
+        m_stored_inner_output_states.d_jcb, d_stored_input_var_a, half_size,
+        cu_output_delta->d_delta_mu, cu_output_delta->d_delta_var,
+        m_overfit_mu);  // Pass the flag here
+
+    cu_output_delta->actual_size = this->input_size;
+    cu_output_delta->block_size = cu_input_delta->block_size;
+
+    // Free memory used for storing inner states.
+    // The other d_stored_* pointers are just views and don't own memory.
+    cudaFree(m_stored_inner_output_states.d_mu_a);
+    cudaFree(m_stored_inner_output_states.d_var_a);
+    cudaFree(m_stored_inner_output_states.d_jcb);
+    m_stored_inner_output_states.d_mu_a = nullptr;
+    m_stored_inner_output_states.d_var_a = nullptr;
+    m_stored_inner_output_states.d_jcb = nullptr;
+    d_stored_input_var_a = nullptr;
+    d_stored_output_mu_a = nullptr;
+    d_stored_output_var_a = nullptr;
 }

--- a/src/bindings/activation_bindings.cpp
+++ b/src/bindings/activation_bindings.cpp
@@ -152,24 +152,6 @@ void bind_softmax(pybind11::module_& modo)
         .def("to_cuda", &Softmax::to_cuda);
 }
 
-void bind_even_exp(pybind11::module_& modo)
-/*
- */
-{
-    pybind11::class_<EvenExp, std::shared_ptr<EvenExp>, BaseLayer>(modo,
-                                                                   "EvenExp")
-        .def(pybind11::init<>())
-        .def("get_layer_info", &EvenExp::get_layer_info)
-        .def("get_layer_name", &EvenExp::get_layer_name)
-        .def("get_layer_type", &EvenExp::get_layer_type)
-        .def("forward", &EvenExp::forward)
-        .def("update_weights", &EvenExp::update_weights)
-        .def("update_biases", &EvenExp::update_biases)
-        .def("load", &EvenExp::load)
-        .def("save", &EvenExp::save)
-        .def("to_cuda", &EvenExp::to_cuda);
-}
-
 void bind_remax(pybind11::module_& modo)
 /*
  */
@@ -196,4 +178,70 @@ void bind_closed_form_softmax(pybind11::module_& modo)
         .def("get_layer_info", &ClosedFormSoftmax::get_layer_info)
         .def("get_layer_name", &ClosedFormSoftmax::get_layer_name)
         .def("forward", &ClosedFormSoftmax::forward);
+}
+
+void bind_split_activation(pybind11::module_& modo)
+/*
+ */
+{
+    pybind11::class_<SplitActivation, std::shared_ptr<SplitActivation>,
+                     BaseLayer>(modo, "SplitActivation")
+        // Bind the new constructor
+        .def(pybind11::init<std::shared_ptr<BaseLayer>,
+                            std::shared_ptr<BaseLayer>>(),
+             "Initializes the SplitActivation layer.",
+             pybind11::arg("odd_layer"),
+             pybind11::arg("even_layer") =
+                 nullptr)  // Define named, optional argument
+
+        // The rest of the functions are bound as before
+        .def("get_layer_info", &SplitActivation::get_layer_info)
+        .def("get_layer_name", &SplitActivation::get_layer_name)
+        .def("get_layer_type", &SplitActivation::get_layer_type)
+        .def("forward", &SplitActivation::forward)
+        .def("update_weights", &SplitActivation::update_weights)
+        .def("update_biases", &SplitActivation::update_biases)
+        .def("load", &SplitActivation::load)
+        .def("save", &SplitActivation::save)
+        .def("to_cuda", &SplitActivation::to_cuda);
+}
+
+void bind_exp(pybind11::module_& modo)
+/*
+ */
+{
+    pybind11::class_<Exp, std::shared_ptr<Exp>, BaseLayer>(modo, "Exp")
+        .def(pybind11::init<float, float>(), pybind11::arg("scale") = 1.0f,
+             pybind11::arg("shift") = 0.0f)
+        .def("get_layer_info", &Exp::get_layer_info)
+        .def("get_layer_name", &Exp::get_layer_name)
+        .def("get_layer_type", &Exp::get_layer_type)
+        .def("forward", &Exp::forward)
+        .def("update_weights", &Exp::update_weights)
+        .def("update_biases", &Exp::update_biases)
+        .def("load", &Exp::load)
+        .def("save", &Exp::save)
+        .def("to_cuda", &Exp::to_cuda);
+}
+
+void bind_agvi(pybind11::module_& modo) {
+    pybind11::class_<AGVI, std::shared_ptr<AGVI>, BaseLayer>(modo, "AGVI")
+        .def(pybind11::init<std::shared_ptr<BaseLayer>, bool, bool>(),
+             pybind11::arg("activation_layer"),
+             pybind11::arg_v(
+                 "overfit_mu", true,
+                 "If true, use a different Jacobian for the mean delta"),
+             pybind11::arg_v("agvi", true,
+                             "If true, use the AGVI learned noise model"))
+
+        .def("get_layer_info", &AGVI::get_layer_info)
+        .def("get_layer_name", &AGVI::get_layer_name)
+        .def("get_layer_type", &AGVI::get_layer_type)
+        .def("forward", &AGVI::forward)
+        .def("backward", &AGVI::backward)
+        .def("update_weights", &AGVI::update_weights)
+        .def("update_biases", &AGVI::update_biases)
+        .def("load", &AGVI::load)
+        .def("save", &AGVI::save)
+        .def("to_cuda", &AGVI::to_cuda);
 }

--- a/src/bindings/activation_bindings.cpp
+++ b/src/bindings/activation_bindings.cpp
@@ -242,8 +242,9 @@ void bind_exp(pybind11::module_& modo)
 
 void bind_agvi(pybind11::module_& modo) {
     pybind11::class_<AGVI, std::shared_ptr<AGVI>, BaseLayer>(modo, "AGVI")
-        .def(pybind11::init<std::shared_ptr<BaseLayer>, bool, bool>(),
-             pybind11::arg("activation_layer"),
+        .def(pybind11::init<std::shared_ptr<BaseLayer>,
+                            std::shared_ptr<BaseLayer>, bool, bool>(),
+             pybind11::arg("odd_layer"), pybind11::arg("even_layer") = nullptr,
              pybind11::arg_v(
                  "overfit_mu", true,
                  "If true, use a different Jacobian for the mean delta"),
@@ -253,6 +254,10 @@ void bind_agvi(pybind11::module_& modo) {
         .def("get_layer_info", &AGVI::get_layer_info)
         .def("get_layer_name", &AGVI::get_layer_name)
         .def("get_layer_type", &AGVI::get_layer_type)
+        .def("set_overfit_mu", &AGVI::set_overfit_mu)
+        .def("get_overfit_mu", &AGVI::get_overfit_mu)
+        .def("set_agvi", &AGVI::set_agvi)
+        .def("get_agvi", &AGVI::get_agvi)
         .def("forward", &AGVI::forward)
         .def("backward", &AGVI::backward)
         .def("update_weights", &AGVI::update_weights)

--- a/src/bindings/activation_bindings.cpp
+++ b/src/bindings/activation_bindings.cpp
@@ -121,8 +121,8 @@ void bind_softplus(pybind11::module_& modo)
 /*
  */
 {
-    pybind11::class_<Softplus, std::shared_ptr<Softplus>, BaseLayer>(
-        modo, "MixtureSoftplus")
+    pybind11::class_<Softplus, std::shared_ptr<Softplus>, BaseLayer>(modo,
+                                                                     "Softplus")
         .def(pybind11::init<>())
         .def("get_layer_info", &Softplus::get_layer_info)
         .def("get_layer_name", &Softplus::get_layer_name)

--- a/src/bindings/activation_bindings.cpp
+++ b/src/bindings/activation_bindings.cpp
@@ -101,6 +101,22 @@ void bind_mixture_tanh(pybind11::module_& modo)
         .def("to_cuda", &MixtureTanh::to_cuda);
 }
 
+void bind_celu(pybind11::module_& modo)
+/*
+ */
+{
+    pybind11::class_<CELU, std::shared_ptr<CELU>, BaseLayer>(modo, "CELU")
+        .def(pybind11::init<>())
+        .def("get_layer_info", &CELU::get_layer_info)
+        .def("get_layer_name", &CELU::get_layer_name)
+        .def("forward", &CELU::forward)
+        .def("update_weights", &CELU::update_weights)
+        .def("update_biases", &CELU::update_biases)
+        .def("load", &CELU::load)
+        .def("save", &CELU::save)
+        .def("to_cuda", &CELU::to_cuda);
+}
+
 void bind_softplus(pybind11::module_& modo)
 /*
  */

--- a/src/bindings/main_bindings.cpp
+++ b/src/bindings/main_bindings.cpp
@@ -17,7 +17,6 @@ PYBIND11_MODULE(cutagi, modo) {
     bind_softplus(modo);
     bind_leakyrelu(modo);
     bind_softmax(modo);
-    bind_even_exp(modo);
     bind_linear_layer(modo);
     bind_slinear_layer(modo);
     bind_conv2d_layer(modo);
@@ -45,4 +44,7 @@ PYBIND11_MODULE(cutagi, modo) {
     bind_nccl_available(modo);
     bind_remax(modo);
     bind_closed_form_softmax(modo);
+    bind_split_activation(modo);
+    bind_exp(modo);
+    bind_agvi(modo);
 }

--- a/src/bindings/main_bindings.cpp
+++ b/src/bindings/main_bindings.cpp
@@ -14,6 +14,7 @@ PYBIND11_MODULE(cutagi, modo) {
     bind_mixture_relu(modo);
     bind_mixture_sigmoid(modo);
     bind_mixture_tanh(modo);
+    bind_celu(modo);
     bind_softplus(modo);
     bind_leakyrelu(modo);
     bind_softmax(modo);

--- a/src/output_updater_cuda.cu
+++ b/src/output_updater_cuda.cu
@@ -91,14 +91,16 @@ __global__ void update_delta_z_cuda_heteros(float const *mu_a,
         float var_sum = var_a_col + mu_v2;
 
         // Compute updating quantities for the mean of the output
-        float tmp = jcb_col / var_sum;
-        if (std::isinf(tmp) || std::isnan(tmp)) {
+        float tmp_mu = jcb_col / var_a_col;
+        float tmp_var = jcb_col / var_sum;
+        if (std::isinf(tmp_mu) || std::isnan(tmp_mu) || std::isinf(tmp_var) ||
+            std::isnan(tmp_var)) {
             delta_mu[obs_col] = zero_pad;
             delta_var[obs_col] = zero_pad;
         } else {
             float obs_diff = obs[col] - mu_a_col;
-            delta_mu[obs_col] = tmp * obs_diff;
-            delta_var[obs_col] = -tmp * jcb_col;
+            delta_mu[obs_col] = tmp_mu * obs_diff;
+            delta_var[obs_col] = -tmp_var * jcb_col;
         }
 
         // Compute the posterior mean and variance for V

--- a/src/output_updater_cuda.cu
+++ b/src/output_updater_cuda.cu
@@ -1,5 +1,6 @@
 #include "../include/custom_logger.h"
 #include "../include/output_updater_cuda.cuh"
+
 __global__ void update_delta_z_using_indices_cuda(
     float const *mu_a, float const *var_a, float const *jcb, float const *obs,
     float const *var_obs, int const *selected_idx, int n_obs, int n_enc,
@@ -99,7 +100,7 @@ __global__ void update_delta_z_cuda_heteros(float const *mu_a,
             delta_var[obs_col] = zero_pad;
         } else {
             float obs_diff = obs[col] - mu_a_col;
-            delta_mu[obs_col] = tmp_var * obs_diff;
+            delta_mu[obs_col] = tmp_mu * obs_diff;
             delta_var[obs_col] = -tmp_var * jcb_col;
         }
 

--- a/src/output_updater_cuda.cu
+++ b/src/output_updater_cuda.cu
@@ -99,7 +99,7 @@ __global__ void update_delta_z_cuda_heteros(float const *mu_a,
             delta_var[obs_col] = zero_pad;
         } else {
             float obs_diff = obs[col] - mu_a_col;
-            delta_mu[obs_col] = tmp_mu * obs_diff;
+            delta_mu[obs_col] = tmp_var * obs_diff;
             delta_var[obs_col] = -tmp_var * jcb_col;
         }
 

--- a/test/cpp_unit/test_fnn_heteros.cpp
+++ b/test/cpp_unit/test_fnn_heteros.cpp
@@ -146,7 +146,8 @@ class SineSignalHeterosTest : public ::testing::Test {
 };
 
 TEST_F(SineSignalHeterosTest, HeterosNoiseTest_CPU) {
-    Sequential model(Linear(13, 16), ReLU(), Linear(16, 2), EvenExp());
+    Sequential model(Linear(13, 16), ReLU(), Linear(16, 2),
+                     SplitActivation(std::make_shared<Exp>()));
     model.set_threads(2);
 
     float avg_error;
@@ -162,7 +163,8 @@ TEST_F(SineSignalHeterosTest, HeterosNoiseTest_CPU) {
 #ifdef USE_CUDA
 TEST_F(SineSignalHeterosTest, HeterosNoiseTest_CUDA) {
     if (!g_gpu_enabled) GTEST_SKIP() << "GPU tests are disabled.";
-    Sequential model(Linear(13, 16), ReLU(), Linear(16, 2), EvenExp());
+    Sequential model(Linear(13, 16), ReLU(), Linear(16, 2),
+                     SplitActivation(std::make_shared<Exp>()));
     model.to_device("cuda");
 
     float avg_error;

--- a/test/py_unit/test_fnn_heteros.py
+++ b/test/py_unit/test_fnn_heteros.py
@@ -8,7 +8,14 @@ import pytagi
 import pytagi.metric as metric
 from examples.data_loader import RegressionDataLoader
 from pytagi import Normalizer
-from pytagi.nn import EvenExp, Linear, OutputUpdater, ReLU, Sequential
+from pytagi.nn import (
+    Exp,
+    Linear,
+    OutputUpdater,
+    ReLU,
+    Sequential,
+    SplitActivation,
+)
 
 # path to binding code
 sys.path.append(
@@ -85,7 +92,7 @@ class SineSignalHeterosTest(unittest.TestCase):
             Linear(32, 32),
             ReLU(),
             Linear(32, 2),
-            EvenExp(),
+            SplitActivation(Exp()),
         )
         mse = heteros_test_runner(model)
         self.assertLess(
@@ -102,7 +109,7 @@ class SineSignalHeterosTest(unittest.TestCase):
             Linear(32, 32),
             ReLU(),
             Linear(32, 2),
-            EvenExp(),
+            SplitActivation(Exp()),
         )
         mse = heteros_test_runner(model, use_cuda=True)
         self.assertLess(


### PR DESCRIPTION
## Description


This update introduces the `AGVI` layer to replace the `EvenExp` layer to estimate the aleatoric uncertainty. This change simplifies the model's output from `2A` to a single `A` value, which makes it possible to stack other layers on top, such as Softmax or Remax.

This implementation also address a major challenge with large models and datasets where training becomes impossible due to the non-identifiability of error the noise. The new layer explicitly incorporates mean overfitting when updating the `Z output`.

Finally, the AGVI layer can use any activation function internally to ensure that the `V2bar` means remain positive.

## Changes Made

- Added AGVI layer on both CPU and CUDA and added corresponding bindings for Python. This layer includes forward and backward pass in order to correctly update `V2bar`.
- To prevent the model from becoming "lazy," it overfits the `delta_mu` while allowing the `delta_var` to incorporate the inherent aleatoric uncertainty of the data.
- Added Exp activation function layer on bot C++ and CUDA with corresponding bindings.
- Added C++ and Python unit tests for AGVI layer. Right now they only check for metrics and compares with threshold. I manually checked if the results are the same for the `EvenExp` layer with `heteros_update` and `AGVI(Exp())` layer with `update` and `var_obs=0`, and it is the same whenever we don't overfit `delta_mu`. 

## Checklist

- [x]  I have followed the project's coding conventions and style guidelines.
- [x]  I have updated the documentation, if applicable.
- [x]  I have rebased my branch on the latest upstream code to incorporate any changes.
- [x]  I have tested the changes locally by running the following tests on a CUDA-installed device

    ```shell
    build/run_tests
    ```
    ```shell
    python -m test.py_unit.main
    ```



## Notes for Reviewers

Please run both C++ and Python tests to verify correct performance. Also you can verify the correctness of the implementation by using the layer on different datasets by:

   ```shell
    python -m examples.agvi_regression
   ```

   ```shell
    python -m examples.agvi_mnist
   ```

   ```shel
    python -m examples.agvi_cifar
   ```

### Table with Small UCI benchmark:

| Dataset | cuTAGI v0 (RMSE) | cuTAGI v0 (Log-likelihood) | cuTAGI v0 (Avg training time) | cuTAGI v1 (SplitActivation(Exp())) (RMSE) | cuTAGI v1 (SplitActivation(Exp())) (Log-likelihood) | cuTAGI v1 (SplitActivation(Exp())) (Avg training time) | cuTAGI v1 (AGVI) (RMSE) | cuTAGI v1 (AGVI) (Log-likelihood) | cuTAGI v1 (AGVI) (Avg training time) |
| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
| **Boston_housing** | 3.326 ± 1.032 | -2.568 ± 0.326 | 0.109 ± 0.001 | 3.619 ± 1.045 | -2.737 ± 0.461 | 0.162 ± 0.050 | 3.443 ± 0.821 | -2.762 ± 0.414 | 0.210 ± 0.062 |
| **Concrete** | 6.274 ± 0.575 | -3.188 ± 0.209 | 0.269 ± 0.005 | 6.141 ± 0.666 | -3.375 ± 0.273 | 0.469 ± 0.129 | 5.937 ± 0.652 | -3.326 ± 0.309 | 0.444 ± 0.116 |
| **Energy** | 2.243 ± 0.319 | -1.664 ± 0.444 | 0.265 ± 0.004 | 0.567 ± 0.091 | -0.927 ± 0.377 | 0.526 ± 0.118 | 0.607 ± 0.139 | -0.997 ± 0.514 | 0.499 ± 0.160 |
| **Yacht** | 1.498 ± 0.672 | -1.422 ± 0.703 | 0.206 ± 0.002 | 0.875 ± 0.296 | -1.356 ± 1.149 | 0.863 ± 0.156 | 0.984 ± 0.376 | -1.114 ± 0.501 | 0.876 ± 0.113 |
| **Wine** | 0.638 ± 0.037 | -0.984 ± 0.105 | 0.257 ± 0.006 | 0.680 ± 0.041 | -1.090 ± 0.153 | 0.410 ± 0.114 | 0.678 ± 0.042 | -1.072 ± 0.113 | 0.456 ± 0.150 |
| **Kin8nm** | 0.122 ± 0.010 | 0.942 ± 0.041 | 3.002 ± 0.049 | 0.080 ± 0.003 | 1.038 ± 0.062 | 3.734 ± 0.996 | 0.079 ± 0.004 | 1.040 ± 0.079 | 3.922 ± 1.094 |
| **Naval** | 0.007 ± 0.000 | 3.738 ± 0.066 | 8.885 ± 0.078 | 0.007 ± 0.000 | 3.478 ± 0.015 | 1.922 ± 0.038 | 0.007 ± 0.001 | 3.524 ± 0.176 | 2.591 ± 1.657 |
| **Power-plant** | 4.163 ± 0.150 | -2.830 ± 0.039 | 1.639 ± 0.008 | 4.278 ± 0.200 | -2.979 ± 0.072 | 2.804 ± 1.005 | 4.223 ± 0.163 | -2.973 ± 0.052 | 3.036 ± 0.946 |
| **Protein** | 4.726 ± 0.034 | -2.889 ± 0.029 | 12.622 ± 0.130 | 4.732 ± 0.068 | -2.955 ± 0.022 | 14.301 ± 4.358 | 4.847 ± 0.151 | -3.031 ± 0.056 | 15.753 ± 2.952 |
*All the example, trained models, images and notebooks will be removed after verification. We may want to keep the `EvenExp` layer, cause it will allow to easily access both aleatoric and epistemic uncertainty.*