### PR TITLE
Bugfix/Change mean for sum in the log-likelihood calculation

### DIFF
--- a/pytagi/metric.py
+++ b/pytagi/metric.py
@@ -101,7 +101,7 @@ def log_likelihood(
     log_lik = -0.5 * np.log(2 * np.pi * (std**2)) - 0.5 * (
         ((observation - prediction) / std) ** 2
     )
-    return np.nanmean(log_lik)
+    return np.nansum(log_lik)
 
 
 def rmse(prediction: np.ndarray, observation: np.ndarray) -> float:


### PR DESCRIPTION
## Description

The log-likelihood calculation has a bug where it uses 'nanmean' instead of 'nansum' as it is supposed to.

## Changes Made

in 'metric.log_likelihood(), 'nanmean' has been replaced by 'nansum' 

## Related Issue(s)

N/A

## Checklist

- [x]  I have followed the project's coding conventions and style guidelines.
- [N/A]  I have updated the documentation, if applicable.
- [x]  I have rebased my branch on the latest upstream code to incorporate any changes.
- [x]  I have tested the changes locally by running the following tests on a CUDA-installed device

    ```shell
    build/run_tests
    ```
    ```shell
    python -m test.py_unit.main
    ```



## Notes for Reviewers

1 - I noticed that when running the test on CPU there is no issue. However, when running on GPU, some CNN/Resnet-based tests fails depending on the initial seed. Re-running the test a second time would leads to a different set of tests that fails.

2- I also noticed that the test related to 'MultiheadAttention' do not pass on GPU. 

Both of these issues are unrelated and unaffected by this PR.  


